### PR TITLE
Fix magnetometer colour code in plotImu

### DIFF
--- a/bimvee/plotImu.py
+++ b/bimvee/plotImu.py
@@ -69,7 +69,9 @@ def plotImu(inDict, **kwargs):
     axesAngV.legend(['x', 'y', 'z'])
 
     axesMag = allAxes[2]
-    axesMag.plot(inDict['ts'], inDict['mag'])
+    axesMag.plot(inDict['ts'], inDict['mag'][:, 0], 'r')
+    axesMag.plot(inDict['ts'], inDict['mag'][:, 1], 'g')
+    axesMag.plot(inDict['ts'], inDict['mag'][:, 2], 'b')
     axesMag.set_title('Mag (uT)')
     axesMag.legend(['x', 'y', 'z'])
 


### PR DESCRIPTION
Use the same colour code as accelerations and angular velocities for magnetometer values.

This is what we had before:

![image](https://user-images.githubusercontent.com/12125604/97336997-faa59180-187f-11eb-902c-7b61f0acf576.png)


This fix makes the three plots coherent in terms of color code:

![image](https://user-images.githubusercontent.com/12125604/97336689-91be1980-187f-11eb-8052-a9fe7ad7e265.png)
