### PR TITLE
Fix makeQuaternionsContinuous function

### DIFF
--- a/bimvee/pose.py
+++ b/bimvee/pose.py
@@ -2,27 +2,27 @@
 """
 Copyright (C) 2020 Event-driven Perception for Robotics
 Authors: Sim Bamford
-         Aiko Dinale   
+         Aiko Dinale
 
-This program is free software: you can redistribute it and/or modify it under 
-the terms of the GNU General Public License as published by the Free Software 
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
 Foundation, either version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY 
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with 
+You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 
-Intended as part of bimvee (Batch Import, Manipulation, Visualisation 
+Intended as part of bimvee (Batch Import, Manipulation, Visualisation
                             and Export of Events etc)
 Functions for manipulating 3D 6DOF poses
 
-A set of functions for manipulating dictionaries containing timestamped sets 
+A set of functions for manipulating dictionaries containing timestamped sets
 of 3D poses.
 The typical dictionary format is:
 
 {
-*	'ts': numpy array (n) of np.float64 - timestamps in seconds, assumed to be 
+*	'ts': numpy array (n) of np.float64 - timestamps in seconds, assumed to be
                             sorted ascending,
 *	'point': numpy array (n, 3) of np.float64, where each row contains [x, y, z],
 *	'rotation': see below for different pose formats,
@@ -33,26 +33,26 @@ So the nth point and the nth rotation represent the pose at the nth timestamp.
 
 The rotation may be either:
 
-* Unit quaternion: (n, 4) where each row contains [w, x, y, z] (NOTE! ordering 
-                          of quaternion elements may differ in other software 
+* Unit quaternion: (n, 4) where each row contains [w, x, y, z] (NOTE! ordering
+                          of quaternion elements may differ in other software
                           frameworks, e.g. ROS uses [x, y, z, w]
 * Rotation matrix: (n, 3, 3)
 * Rodrigues vector: (n, 3)
-* Axis-Angle: (n, 1) this is the angle of axis-angle representation, there is 
+* Axis-Angle: (n, 1) this is the angle of axis-angle representation, there is
                      then a further field called 'axis' (n, 3)
 
-We will name these formats differently depending on the rotation representation, 
+We will name these formats differently depending on the rotation representation,
 respectively:
 
 pose6q
 pose6mat
-pose6rvec 
+pose6rvec
 pose6axang
 
-In the case of 'mat', there is a further field 'transformation', (n, 4, 4) 
-which contains transformation matrices for each timestamp. In fact, the 'point' 
-and 'rotation' fields in this case are simply views to the appropriate parts 
-of 'transformation', i.e. [n, :3, 3] and [n, :3, :3] respectively. 
+In the case of 'mat', there is a further field 'transformation', (n, 4, 4)
+which contains transformation matrices for each timestamp. In fact, the 'point'
+and 'rotation' fields in this case are simply views to the appropriate parts
+of 'transformation', i.e. [n, :3, 3] and [n, :3, :3] respectively.
 
 There are functions to translate one rotation representation to another:
 
@@ -61,7 +61,7 @@ rotToVec(dict)
 rotToQuat(dict)
 rotToAxisAngle(dict)
 
-Each of the above deduces the type from the dimensions of 'rotation' before 
+Each of the above deduces the type from the dimensions of 'rotation' before
 applying the appropriate transformation.
 
 There are these additional functions, which apply to all samples in a pose dict:
@@ -75,18 +75,18 @@ averageRotation(dict, weights=None)
 
 There are also these forms, which work sample-wise between two dicts:
 
-transform(dict1, rotation=dict2) - applies as if the dicts contained mats 
+transform(dict1, rotation=dict2) - applies as if the dicts contained mats
                                     and the result were: dict2 @ dict1
 angleBetween(dict1, rotation=dict2)
 
-In both of the above cases, if the dicts do not have identical timstamps, 
-then the resulting dict has a result at each time in each dict 
-which is contained within the bounds of the timestamps in the other dict 
-- i.e. interpolation is used to align the data intime. 
+In both of the above cases, if the dicts do not have identical timstamps,
+then the resulting dict has a result at each time in each dict
+which is contained within the bounds of the timestamps in the other dict
+- i.e. interpolation is used to align the data intime.
 
-There are lower level functions which don't operate on dicts but rather 
-on the appropriate arrays and on singular samples; these are exposed and can 
-be imported for convenience. 
+There are lower level functions which don't operate on dicts but rather
+on the appropriate arrays and on singular samples; these are exposed and can
+be imported for convenience.
 """
 
 import numpy as np
@@ -126,7 +126,7 @@ def rotToRepresentation(inDict, rotationRepresentation):
         return rotToVec(inDict)
     else: #rotationRepresentation == 'mat'
         return rotToMat(inDict)
-        
+
 
 def rotToMat(inDict):
     rotation = inDict['rotation']
@@ -142,7 +142,7 @@ def rotToMat(inDict):
     outDict['point'] = mat[:, :3, 3]
     outDict['rotation'] = mat[:, :3, :3]
     outDict['transformation'] = mat
-        
+
     if rotationRepresentation == 'axisAngle':
         angle = rotation
         axis = inDict['axis']
@@ -159,7 +159,7 @@ def rotToMat(inDict):
         mat[:, 1, 0] = y * x * (1 - cos) + z * sin
         mat[:, 1, 1] = cos + y**2 * (1 - cos)
         mat[:, 1, 2] = y * z * (1 - cos) - x * sin
-        mat[:, 2, 0] = z * x * (1 - cos) - y * sin 
+        mat[:, 2, 0] = z * x * (1 - cos) - y * sin
         mat[:, 2, 1] = z * y * (1 - cos) + x * sin
         mat[:, 2, 2] = cos + z**2 * (1 - cos)
     elif rotationRepresentation == 'quaternion':
@@ -193,20 +193,20 @@ def rotToMat(inDict):
             Sn[:, 2, 0] = -n[:, 1]
             Sn[:, 2, 1] = n[:, 0]
             return Sn
-        
+
         theta = np.linalg.norm(rotation, axis=1)
         n = rotation / theta
         Sn = S(n, mat)
         Sr = S(r, mat)
         theta2 = theta**2
         cond = theta > 1e-30
-        
+
         def dotAlongZerothAxis(S, mat): # TODO: there is probably a neat numpy way of doing this: tensordot? apply_along_axis?
             out = np.zeros_like(mat)
             for idx, slicee in enumerate(S):
                 out[idx, :, :] = np.dot(S, S)
             return out
-        
+
         mat = mat \
             + cond * ( np.sin(theta)*Sn + (1-np.cos(theta))*dotAlongZerothAxis(Sn, mat) ) \
             + (1-cond) * ((1-theta2/6)*Sr + (0.5-theta2/24)*dotAlongZerothAxis(Sr, mat) )
@@ -221,24 +221,24 @@ def rotToVec(inDict):
         return inDict
     outDict = inDict.copy()
     if rotationRepresentation == 'axisAngle':
-        raise NotImplementedError("Method not implemented") 
+        raise NotImplementedError("Method not implemented")
     elif rotationRepresentation == 'quaternion':
-        raise NotImplementedError("Method not implemented") 
+        raise NotImplementedError("Method not implemented")
     elif rotationRepresentation == 'rVec':
-        raise NotImplementedError("Method not implemented") 
+        raise NotImplementedError("Method not implemented")
     else: #rotationRepresentation == 'mat'
-        raise NotImplementedError("Method not implemented") 
+        raise NotImplementedError("Method not implemented")
     return outDict
-    
+
 def rotToQuat(inDict):
     rotation = inDict['rotation']
     rotationRepresentation = findRotationRepresentation(rotation)
     if rotationRepresentation == 'quaternion':
         return inDict
     if rotationRepresentation == 'axisAngle':
-        raise NotImplementedError("Method not implemented") 
+        raise NotImplementedError("Method not implemented")
     elif rotationRepresentation == 'rVec':
-        raise NotImplementedError("Method not implemented") 
+        raise NotImplementedError("Method not implemented")
     else: #rotationRepresentation == 'mat'
         outDict = inDict.copy()
         # Solution from https://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/
@@ -260,7 +260,7 @@ def rotToQuat(inDict):
         qy = np.zeros(numRotations)
         qz = np.zeros(numRotations)
         for i in range(m.shape[0]):
-            if tr[i] > 0: 
+            if tr[i] > 0:
                 S = np.sqrt(tr[i] + 1.0) * 2
                 qw[i] = 0.25 * S
                 qx[i] = (m21[i] - m12[i]) / S
@@ -272,7 +272,7 @@ def rotToQuat(inDict):
                 qx[i] = 0.25 * S
                 qy[i] = (m01[i] + m10[i]) / S
                 qz[i] = (m02[i] + m20[i]) / S
-            elif m11[i] > m22[i]: 
+            elif m11[i] > m22[i]:
                 S = np.sqrt(1.0 + m11[i] - m00[i] - m22[i]) * 2
                 qw[i] = (m02[i] - m20[i]) / S
                 qx[i] = (m01[i] + m10[i]) / S
@@ -283,7 +283,7 @@ def rotToQuat(inDict):
                 qw[i] = (m10[i] - m01[i]) / S
                 qx[i] = (m02[i] + m20[i]) / S
                 qy[i] = (m12[i] + m21[i]) / S
-                qz[i] = 0.25 * S    
+                qz[i] = 0.25 * S
         outDict['rotation'] = np.concatenate((qw[:, np.newaxis],
                                               qx[:, np.newaxis],
                                               qy[:, np.newaxis],
@@ -291,25 +291,25 @@ def rotToQuat(inDict):
                                               ), axis=1)
         del outDict['transformation']
         return outDict
-    
+
 def rotToAxisAngle(inDict):
     rotation = inDict['rotation']
     rotationRepresentation = findRotationRepresentation(rotation)
     if rotationRepresentation == 'axisAngle':
         return inDict
     if rotationRepresentation == 'quaternion':
-        raise NotImplementedError("Method not implemented") 
+        raise NotImplementedError("Method not implemented")
     elif rotationRepresentation == 'rVec':
-        raise NotImplementedError("Method not implemented") 
+        raise NotImplementedError("Method not implemented")
     else: #rotationRepresentation == 'mat'
-        raise NotImplementedError("Method not implemented") 
-    
+        raise NotImplementedError("Method not implemented")
+
 '''
 Add into the dict two arrays, containing:
 (a) the instantaneous linear speed, calculated as the euclidean distance from
-  one point to the next / divided by the time from one point to the next, 
+  one point to the next / divided by the time from one point to the next,
   using the pairwise average of previous and next to give an estimate for
-  each point. 
+  each point.
 (b) the instantaneous rotational speed, calculated as above expect for angles
 '''
 def calculateSpeed(inDict):
@@ -328,23 +328,23 @@ def calculateSpeed(inDict):
     angularDiffs = angleBetweenTwoQuaternionsArray(rotations[:-1, :], rotations[1:, :])
     inDict['angularSpeed'] = pairwiseMean(angularDiffs / timeDiffs)
     return inDict
-    
+
 def interpolatePoses(inDict, times=None, period=None, maxPeriod=None):
     '''
-    method: based on the inputs times, period and maxPeriod, 
+    method: based on the inputs times, period and maxPeriod,
     create a set of times desired
     crop these outside of the range of the existing times
     Then select original times which are also in the new times
     Then do interpolation for each of the new times
     Then merge the two sets.
-    
-    It would be possible to create sub-implementations for each rotation 
-    representation, but for simplicity we convert to quaternion, do the 
-    interpolation, and convert back again. 
-    
-    This function is not compatible with labelled poses, or any other 
+
+    It would be possible to create sub-implementations for each rotation
+    representation, but for simplicity we convert to quaternion, do the
+    interpolation, and convert back again.
+
+    This function is not compatible with labelled poses, or any other
     non-standard additional fields in the poseDict
-    
+
     '''
     rotation = inDict['rotation']
     rotationRepresentation = findRotationRepresentation(rotation)
@@ -352,11 +352,11 @@ def interpolatePoses(inDict, times=None, period=None, maxPeriod=None):
 
     if np.isscalar(times):
         return interpolatePosesSingle(inDict, time=times)
-    
+
     ts = poseDict['ts']
     points = poseDict['point']
     rotations = poseDict['rotation']
-    
+
     firstTime = ts[0]
     lastTime = ts[-1]
     if times is not None:
@@ -370,7 +370,7 @@ def interpolatePoses(inDict, times=None, period=None, maxPeriod=None):
         timesAlreadyExistBool = np.isin(times, ts)
         existingTimes = times[timesAlreadyExistBool]
         newTimes = times[~timesAlreadyExistBool]
-    elif maxPeriod is not None:        
+    elif maxPeriod is not None:
         proposedAdditionalTimes = np.arange(firstTime, lastTime, maxPeriod)
         prevIds = np.searchsorted(ts, proposedAdditionalTimes, side='right') - 1
         distPre = proposedAdditionalTimes - ts[prevIds]
@@ -380,12 +380,12 @@ def interpolatePoses(inDict, times=None, period=None, maxPeriod=None):
         newTimes = proposedAdditionalTimes[keepAdditional]
         existingTimes = ts
 
-    # Now we have newTimes and existingTimes; 
+    # Now we have newTimes and existingTimes;
     # Now iterate over newTimes and do interpolation
     numNewTimes = len(newTimes)
     newPoints = np.zeros((numNewTimes, 3), dtype=np.float64)
     newRotations = np.zeros((numNewTimes, 4), dtype=np.float64)
-    for idx in range(numNewTimes): 
+    for idx in range(numNewTimes):
         # TODO: slerp function could be vectorised
         # then this whole loop could be vectorised
         newTime = newTimes[idx]
@@ -396,21 +396,21 @@ def interpolatePoses(inDict, times=None, period=None, maxPeriod=None):
         rotPost = rotations[idxPre + 1, :]
         timeRel = (newTime - timePre) / (timePost - timePre)
         newRotations[idx, :] = slerp(rotPre, rotPost, timeRel)
-        pointPre = points[idxPre, :] 
+        pointPre = points[idxPre, :]
         pointPost = points[idxPre + 1, :]
         newPoints[idx, :] = pointPre * (1-timeRel) + pointPost * timeRel
-        
+
     # get existingTimes for merging
     if maxPeriod is None:
         keepExistingBool = np.isin(ts, existingTimes)
         ts = ts[keepExistingBool]
         points = points[keepExistingBool, :]
         rotations = rotations[keepExistingBool, :]
-    
+
     ts = np.concatenate((ts, newTimes))
     points = np.concatenate((points, newPoints))
     rotations = np.concatenate((rotations, newRotations))
-    
+
     newPoseDict = {}
     newPoseDict['ts'] = ts
     newPoseDict['point'] = points
@@ -420,7 +420,7 @@ def interpolatePoses(inDict, times=None, period=None, maxPeriod=None):
             newPoseDict[key] = poseDict[key].copy()
     newPoseDict = sortDataTypeDictByTime(newPoseDict)
     return rotToRepresentation(newPoseDict, rotationRepresentation)
-    
+
 def rotate(inDict, rotation):
     return transform(inDict, rotation=rotation)
 
@@ -428,16 +428,16 @@ def translate(inDict, translation):
     return transform(inDict, translation=translation)
 
 '''
-If you pass in transformationDict, it is applied sample-wise as if the dicts 
+If you pass in transformationDict, it is applied sample-wise as if the dicts
 contained mats and the result were: transformationDict @ poseDict
 If instead you pass in transformationMatrix, then this is applied to the whole
 array thus:
     transformationMatrix @ poseDict
-If instead you pass in either translation or rotation, or both, they are 
+If instead you pass in either translation or rotation, or both, they are
 converted into a transformation matrix, and applied to the whole array.
 If 'direction' is 'reverse' then the multiplication is instead applied:
-    poseDict @ transformationMatrix 
-    
+    poseDict @ transformationMatrix
+
 The implementation here first converts to transformation matrices
 and then converts back at the end
 TODO: There could be efficiency gains by not converting to matrices first
@@ -447,8 +447,8 @@ def transform(inDict, transformationDict=None, transformationMatrix=None,
     rotationRepresentation = findRotationRepresentation(inDict['rotation'])
     inDict = rotToMat(inDict)
     if transformationDict is not None:
-        # Assume that the two dicts have exactly the same timestamps 
-        # TODO: don't assume this but rather interpolate and merge 
+        # Assume that the two dicts have exactly the same timestamps
+        # TODO: don't assume this but rather interpolate and merge
         # following interpolatePoses function
         transformationDict = rotToMat(transformationDict)
         transformation = transformationDict['transformation']
@@ -464,14 +464,14 @@ def transform(inDict, transformationDict=None, transformationMatrix=None,
             if rotation is not None:
                 rotRepOfTransformation = findRotationRepresentationSingle(rotation)
                 if rotRepOfTransformation == 'quaternion':
-                    transformation[:3, :3] = quatToMatSingle(rotation, 
+                    transformation[:3, :3] = quatToMatSingle(rotation,
                                                 M=transformation[:3, :3])
                 elif rotRepOfTransformation == 'mat':
                     transformation[:3, :3] = rotation
                 else:
-                    raise NotImplementedError 
+                    raise NotImplementedError
     if direction in ['normal', 'forward', 'forwards']:
-        transformed = transformation @ inDict['transformation']        
+        transformed = transformation @ inDict['transformation']
     elif direction in ['reverse', 'reversed', 'backward', 'backwards']:
         transformed = inDict['transformation'] @ transformation
     else:
@@ -480,7 +480,7 @@ def transform(inDict, transformationDict=None, transformationMatrix=None,
     outDict['point'] = transformed[:, :3, 3]
     outDict['rotation'] = transformed[:, :3, :3]
     outDict['transformation'] = transformed
-        
+
     return rotToRepresentation(outDict, rotationRepresentation)
 
 # rotation is single
@@ -493,7 +493,7 @@ def angleBetween(inDict, rotation):
     angle = 2 * np.arcsin(normV)
     return outDict
     '''
-    raise NotImplementedError('not implemented') 
+    raise NotImplementedError('not implemented')
 
 def averageRotation(inDict, weights=None):
     # Convert to quaternion
@@ -536,30 +536,33 @@ def makeQuaternionsContinuous(inDict):
     outDict = inDict.copy()
     allQ = outDict['rotation'].copy()
     swapIds = np.where((allQ[:-1, :] * allQ[1:, :]).sum(axis=1) < 0)[0]
+    if len(swapIds) % 2 == 1:
+        swapIds = np.append(swapIds, (len(allQ) - 1))
     swapBool = np.zeros((len(outDict['ts'])), dtype=np.bool)
+
     for swapIdsIdx in range(0, len(swapIds), 2):
         swapBool[swapIds[swapIdsIdx]+1 :swapIds[swapIdsIdx + 1]+1] = True
     allQ[swapBool, :] = - allQ[swapBool, :]
     outDict['rotation'] = allQ
     return outDict
-    
+
 '''
 Offsets all points so that the first is at zero.
 TODO: think of a good way to store the offset, in reference to tsOffset;
-If a np[1,3] array is stored, that will break merge and copy dict functionalities. 
+If a np[1,3] array is stored, that will break merge and copy dict functionalities.
 '''
 def zeroPoint(inDict):
     outDict = inDict.copy()
     outDict['point'] = outDict['point'] - outDict['point'][0, :]
     return outDict
-    
+
 '''
 rotate all the poses so that the first pose is at [1w, 0x, 0y, 0z]
 then offset
 '''
 def zeroPose(inDict):
-    raise NotImplementedError("Method not implemented") 
-    
+    raise NotImplementedError("Method not implemented")
+
 
 #%% Better names for legacy functions
 
@@ -570,8 +573,8 @@ def interpolatePosesSingle(poseDict, time):
     idxPre = np.searchsorted(ts, time, side='right') - 1
     timePre = ts[idxPre]
     if timePre == time:
-        # In this edge-case of desired time == timestamp, there is no need 
-        # to interpolate 
+        # In this edge-case of desired time == timestamp, there is no need
+        # to interpolate
         return (points[idxPre, :], rotations[idxPre, :])
     if idxPre < 0:
         return (points[0, :], rotations[0, :])
@@ -582,15 +585,15 @@ def interpolatePosesSingle(poseDict, time):
     rotPost = rotations[idxPre + 1, :]
     timeRel = (time - timePre) / (timePost - timePre)
     rotOut = slerp(rotPre, rotPost, timeRel)
-    pointPre = points[idxPre, :] 
+    pointPre = points[idxPre, :]
     pointPost = points[idxPre + 1, :]
     pointOut = pointPre * (1-timeRel) + pointPost * timeRel
     return (pointOut, rotOut)
 
-# Can accept an existing matrix, which should be min 3x3; 
+# Can accept an existing matrix, which should be min 3x3;
 #if it creates a matrix it makes it 4x4
 def quatToMatSingle(quat, M=None):
-    if M is None: 
+    if M is None:
         M = np.zeros((4, 4))
         M[3, 3] = 1
     elif M.shape[0] == 4:
@@ -630,21 +633,21 @@ def slerp(q1, q2, time_relative):
     s1 = sin_theta / sin_theta_0
     return (s0 * q1) + (s1 * q2)
 
-''' 
+'''
 expects pose dict in the form: {'ts': 1d np.array of np.float64 timestamps,
-                                'point': 2d array np.float64 of positions [x, y, z], 
+                                'point': 2d array np.float64 of positions [x, y, z],
                                 'rotation': 2d array np.float64 of quaternions [rw, rx, ry, rz]
                                 (i.e. 6dof with rotation as quaternion)}
 Two modes of operation:
 If time is not None, then returns the interpolated pose at that time -
     returns (point, rotation) tuple, being np.array 1d x 3 and 4 respectively, np.float64,    which is interpolated pose;
 Else if maxPeriod is not None, then it returns the entire pose dict,
-    but with additional points necessary to ensure that time between samples 
+    but with additional points necessary to ensure that time between samples
     never exceeds maxPeriod
 '''
 
 def quaternionProductSingle(q1, q2):
-    return np.array([ 
+    return np.array([
     q1[0] * q2[0] - q1[1] * q2[1] - q1[2] * q2[2] - q1[3] * q2[3],
     q1[0] * q2[1] + q1[1] * q2[0] + q1[2] * q2[3] - q1[3] * q2[2],
     q1[0] * q2[2] - q1[1] * q2[3] + q1[2] * q2[0] + q1[3] * q2[1],
@@ -661,19 +664,19 @@ def quaternionProductSingle(q1, q2):
     qOut[1:4] = vOut
     return qOut
     '''
-    
-# Array version of the above    
+
+# Array version of the above
 def quaternionProductArray(q1, q2):
     def x(q, idx): # tis function to clean up the following expression
         return q[:, idx, np.newaxis]
-    return np.concatenate(( 
+    return np.concatenate((
     x(q1,0) * x(q2,0) - x(q1,1) * x(q2,1) - x(q1,2) * x(q2,2) - x(q1,3) * x(q2,3),
     x(q1,0) * x(q2,1) + x(q1,1) * x(q2,0) + x(q1,2) * x(q2,3) - x(q1,3) * x(q2,2),
     x(q1,0) * x(q2,2) - x(q1,1) * x(q2,3) + x(q1,2) * x(q2,0) + x(q1,3) * x(q2,1),
     x(q1,0) * x(q2,3) + x(q1,1) * x(q2,2) - x(q1,2) * x(q2,1) + x(q1,3) * x(q2,0)
     ), axis=1)
 
-    
+
 def quaternionConjugateSingle(q):
     return np.array([q[0], -q[1], -q[2], -q[3]])
 
@@ -688,7 +691,7 @@ def quaternionInverseArray(q):
 
 def angleBetweenTwoQuaternionsSingle(q1, q2):
     # returns minimal angle in radians between two unit quaternions, following:
-    # https://www.researchgate.net/post/How_do_I_calculate_the_smallest_angle_between_two_quaternions    
+    # https://www.researchgate.net/post/How_do_I_calculate_the_smallest_angle_between_two_quaternions
     qP = quaternionProductSingle(q1, quaternionInverseSingle(q2))
     normV = np.linalg.norm(qP[1:])
     return 2 * np.arcsin(normV)
@@ -723,17 +726,17 @@ def rVecToQuatSingle(rotV):
     theta = np.linalg.norm(rotV)
     quat = axisAngleToQuatSingle(rotV[:, 0], theta)
     return quat
-    
+
 '''
-Expects 
+Expects
     - poseDict in bimvee form {'ts', 'point', 'rotation' as above}
     - translation as np array of x,y,z
     - rotation as a np array of w,x,y,z (quaternion)
-If either translation or rotation are passed, these are applied to all poses 
+If either translation or rotation are passed, these are applied to all poses
 in the poseDict.
 The rotations are defined wrt local axes, unlike the translations.
 Returns a copy of the poseDict, rotated
-'''    
+'''
 def transformPosesOld(poseDict, translation=None, rotation=None):
     # Create a copy of the input array - use the same contents
     outDict = {}
@@ -746,12 +749,12 @@ def transformPosesOld(poseDict, translation=None, rotation=None):
             outDict['rotation'][idx, :] = \
                 quaternionProductSingle(outDict['rotation'][idx, :], rotation)
     return outDict
-        
+
 
 # The following adapted from https://github.com/christophhagen/averaging-quaternions
-# Note that the signs of the output quaternion can be reversed, 
+# Note that the signs of the output quaternion can be reversed,
 # since q and -q describe the same orientation.
-# w is an optional weight array, which must have the same number of elements 
+# w is an optional weight array, which must have the same number of elements
 # as the number of quaternions
 def averageOfQuaternions(allQ, w=None):
     # Number of quaternions to average
@@ -790,6 +793,5 @@ def removeDuplicates(poseDict):
     # remove following elements by shifting toKeep dict forwards
     toKeep = np.insert(toKeep, 0, 'True')
     return selectByBool(poseDict, toKeep)
-    
-    
-    
+
+


### PR DESCRIPTION
I noticed that when there is a sign swap in `allQ` over a range between an index `i` and the last index possible for `allQ`, the last index is not stored and the length of `swapIds` is odd making impossible to go through the following for loop:

https://github.com/event-driven-robotics/bimvee/blob/a0d9ab52a8ea820df99fa077de9091f30553dd01/bimvee/pose.py#L543-L544

So, I added these two lines to fix this corner case:

https://github.com/event-driven-robotics/bimvee/blob/a0d9ab52a8ea820df99fa077de9091f30553dd01/bimvee/pose.py#L539-L540

@simbamford I don't know If there are better solutions tough.