### PR TITLE
importiityarp:

### DIFF
--- a/bimvee/importIitYarp.py
+++ b/bimvee/importIitYarp.py
@@ -5,7 +5,9 @@ Authors: Sim Bamford
          Aiko Dinale
          Massimiliano Iacono
 Code contributions from: 
-        marco monforte
+        Marco Monforte
+        Daniel Gutierrez Galan
+        Ali Dabbous
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU General Public License as published by the Free Software 
 Foundation, either version 3 of the License, or (at your option) any later version.
@@ -34,28 +36,38 @@ Each channel is a dict containing:
     For imu:
         - "ts": numpy array of float - seconds
 
-    Can also handle LAE (labelled event) bottles, IMU
+    Can also handle LAE (labelled event) bottles, FLOW (dvs optical flow events), 
+        IMU, SKE (skin), EAR, SKS (skin samples)
 
-This function combines the import of two distinctly different cases:
-    1) pre-split output directly from zynqGrabber
+This function combines the import of several distinctly different cases:
+    1) output directly from zynqGrabber, with all events together
+        May combine samples and events in the same bottles and never contains
+        explicit IMU / LAE / FLOW events. samples such as IMU are contained 
+        within AE type bottles.
     2) split and processed events from vPreProcess or other downstream modules
-The former may combine samples and events in the same bottles and never contains
-explicit IMU / LAE / FLOW events. samples such as IMU are contained within AE type bottles.
-The latter usually has distinct bottles for each datatype, and channels
-have probably, but not definitely, been split into left and right. 
+        The latter usually has distinct bottles for each datatype, and channels
+        have probably, but not definitely, been split into left and right. 
+    3) output from binary event dumper.
+    4) data from vicon
+    5) Skin samples which have not been properly formatted as bottles
+
 TODO: import frames - yarp has 2 ways of encoding - as bottles or,
 recommended, by saving e.g. pngs to a folder - support the latter
+
+There are 2 dvs codecs: 20-bit and 24-bit. 24-bit is assumed unless kwarg 
+"codec" = "20bit" is received
+
+This document gives more principled and complete info for event decoding
+specifically from iCub:
+https://github.com/event-driven-robotics/ed-skin/blob/master/docs/technotes/TN001-Peripherals-to-HPU-Data-Encoding_rev1.pdf
+    
 """
-# TODO: get initial ts from yarp info.log 
-# TODO: support LAE import
-# TODO: support IMU, Skin etc import
 
 #%%
 
 import re
 import numpy as np
 import os
-from tqdm import tqdm
 import struct
 
 # local imports
@@ -63,103 +75,169 @@ from .importIitVicon import importIitVicon
 from .timestamps import unwrapTimestamps, zeroTimestampsForAChannel, rezeroTimestampsForImportedDicts
 from .split import selectByLabel
 
-def decodeEvents(data):
+
+# A parameter for decoding skin events
+def decodeEvents(data, **kwargs):
     '''
-    timestamps(ts) are 32 bit integers counted with an 80 ns clock - do this conversion later 
-    Events are encoded as 32 bits with x,y,channel(ch)(c) and polarity(pol)(p)
+    timestamps(ts) are 32 bit integers counted with an 80 ns clock - do this conversion later
+    There is then a 32 bit data payload.
+    The following patterns mark the different data types (MSB left - LSB right):
+        0000 0XXX XXXX XXXX: dvs
+        0000 1XXX XXXX XXXX: aps
+        0001 0XXX XXXX XXXX: skin
+        0010 0XXX XXXX XXXX: imu
+        0100 0XXX XXXX XXXX: ear
+    DVS events are encoded as 32 bits with x,y,channel(ch)(c) and polarity(pol)(p)
     in two possible configuration as shown below:
-    0000 0000 000c 00yy yyyy yyxx xxxx xxxp (this codec is now deprecated but useful to load old datasets)
-    0000 0000 tcrr yyyy yyyy rrxx xxxx xxxp
-    We could pick out the following event types as follows:
-    data[:, 1] >>= 1
-    aps  = np.uint8(data[:, 1] & 0x01)
-    data[:, 1] >>= 1
-    skin  = np.uint8(data[:, 1] & 0x01)    
-    data[:, 1] >>= 1
-    imu  = np.uint8(data[:, 1] & 0x01)    
-    data[:, 1] >>= 1
-    audio  = np.uint8(data[:, 1] & 0x01)
-    '''
-    isNotDvsEvent = np.bool_(data[:, 1] & 0xFF800000)
-
-    # If any non zero value shows up in bits 18-19 then we are sure that the new 24 bit codec is being used
-    if not hasattr(decodeEvents, "is24bitCodec"):
-        decodeEvents.is24bitCodec = np.bool_(data[:, 1] & 0x00C00000).any()
-    else:
-        if not np.bool_(data[:, 1] & 0x00C00000).any() == decodeEvents.is24bitCodec:
-            # Same codec must be valid across entire dataset
-            raise ValueError("Data codec not consistent or data check not valid")
-
-    if not decodeEvents.is24bitCodec:
-        ts = data[:, 0]
-        pol  = ~np.bool_(data[:, 1] & 0x01) # We want True=ON=brighter, False=OFF=darker, so we negate
-        data[:, 1] >>= 1
-        x = np.uint16(data[:, 1] & 0x1FF)
-        data[:, 1] >>= 9
-        y = np.uint16(data[:, 1] & 0xFF)
-        data[:, 1] >>= 10
-        ch = np.uint8(data[:, 1] & 0x01)
-        dvsOut = {
-            'ts': ts,
-            'ch': ch,
-            'x': x,
-            'y': y,
-            'pol': pol
-        }
-        return dvsOut, None
-
-    if np.any(isNotDvsEvent):
-        dataSample = data[isNotDvsEvent, :]
-        #ts = np.float64(dataSample[:, 0] & ~(0x1 << 31)) * 0.00000008 # convert ts to seconds
-        ts = np.uint32(dataSample[:, 0])
-        if np.isscalar(ts):
-            ts = np.ones((1), dtype=np.uint32) * ts
-        ''' For now assuming that sample is IMU - later need to consider other samples: skin, audio etc
-        Struct of imu sample is (from MSB left to LSB right):
+        0000 0000 000c 00yy yyyy yyxx xxxx xxxp ("20-bit codec" - this codec is now deprecated but useful to load old datasets)
+        0000 0000 0crr yyyy yyyy rrxx xxxx xxxp ("24 bit codec")
+    ... where:
+            - x and y = respective coords;
+            - p = polarity; 
+            - r = reserved for future expansion, but practically used for larger sensor formats
+            - c = channel 1 = right vs 0 = left.
+    APS:
+        not written yet
+    IMU samples:
         rrrr rrrr tcrr ssss vvvv vvvv vvvv vvvv
         r = reserved = 0
         t = type: 1=sample
         c = channel (left vs right)
         s = sensor (uint4)
         v = value of the sample (int16)
-        '''
-        value = np.int16(dataSample[:, 1] & 0xFFFF)
-        dataSample[:, 1] >>= 16
-        sensor = np.uint8(dataSample[:, 1] & 0x0F)
-        dataSample[:, 1] >>= 6
-        ch  = np.uint8(dataSample[:, 1] & 0x01)
-        samplesOut = {
-                'ts': ts,
-                'ch': ch,
-                'sensor': sensor,
-                'value': value
-            }
-    else:
-        samplesOut = None
-    if np.any(~isNotDvsEvent):
-        dataDvs = data[~isNotDvsEvent, :]
-        # convert ts to seconds
-        #ts = np.float64(dataDvs[:, 0] & ~(0x1 << 31)) * 0.00000008 # convert ts to seconds
-        ts = np.uint32(dataDvs[:, 0])
+    SKE (skin) events:
+        0001 0000 TsRR Rbbb RRcR Rttt tttt tttp
+        polarity(p) - bool
+        taxel(t) - uint16
+        cross_base(c) - bool - for events we can ignore this
+        body_part(b) - uint8
+        side(s) - uint8 (could be bool)
+        type(T) - uint8 (could be bool) - 0 for events, 1 for samples
+        reserved (R)
+    EAR (Cochlear / audio) events:
+        0000 0sss 0css snnn nnnn rrmo ffff fffp
+        polarity          (p: 0 -> positive; 1 -> negative)
+        frequency channel (f: from 0 to 31)
+        olive model       (o: 0 -> MSO; 1 -> LSO)
+        auditory model    (m: 0 -> cochlea; 1 -> superior olivary complex)
+        reserved          (r: fixed to 0)
+        ITD neurons id    (n: from 0 to 15)
+        sensor ID         (s: fixed to b'100')
+        channel           (c: 0 -> left; 1 -> right)        
+    '''
+    dvsBool = np.logical_not(data[:, 1] & 0xFF800000)
+    apsBool = np.bool_(data[:, 1] & 0x00800000)
+    skinBool = np.bool_(data[:, 1] & 0x01000000)
+    imuBool = np.bool_(data[:, 1] & 0x02000000)
+    earBool = np.bool_(data[:, 1] & 0x04000000)
+    if kwargs.get('codec', '24bit') == '20bit':
+        dvsBool[:] = True
+        apsBool[:] = False
+        skinBool[:] = False
+        imuBool[:] = False
+        earBool[:] = False
+
+    outDict = {
+        'dvs': None,
+        'aps': None,
+        'skinSamples': None,
+        'skinEvents': None,
+        'imuSamples': None,
+        'ear': None,
+        }
+    if np.any(dvsBool):
+        dataDvs = data[dvsBool, :]
+        ts = dataDvs[:, 0]
         if np.isscalar(ts):
             ts = np.ones((1), dtype=np.uint32) * ts
         pol  = ~np.bool_(dataDvs[:, 1] & 0x01) # We want True=ON=brighter, False=OFF=darker, so we negate
         dataDvs[:, 1] >>= 1
-        x = np.uint16(dataDvs[:, 1] & 0x1FF)
-        dataDvs[:, 1] >>= 11
-        y = np.uint16(dataDvs[:, 1] & 0xFF)
-        dataDvs[:, 1] >>= 10
+        if kwargs.get('codec', '24bit') == '20bit':
+            # If any non zero value shows up in bits 18-19 then we are sure that the new 24 bit codec is being used
+            if np.bool_(dataDvs[:, 1] & 0x00C00000).any():
+                raise ValueError("Data codec not consistent or data check not valid")
+            x = np.uint16(dataDvs[:, 1] & 0x1FF)
+            dataDvs[:, 1] >>= 9
+            y = np.uint16(dataDvs[:, 1] & 0xFF)
+            dataDvs[:, 1] >>= 10
+        else: # 24bit - defaul;t
+            x = np.uint16(dataDvs[:, 1] & 0x7FF)
+            dataDvs[:, 1] >>= 11
+            y = np.uint16(dataDvs[:, 1] & 0x3FF)
+            dataDvs[:, 1] >>= 10
         ch  = np.uint8(dataDvs[:, 1] & 0x01)
-        dvsOut = {
+        outDict['dvs'] = {
+            'ts': ts,
+            'ch': ch,
+            'x': x,
+            'y': y,
+            'pol': pol}
+
+    if np.any(imuBool):
+        dataImu = data[imuBool, :]
+        ts = np.uint32(dataImu[:, 0])
+        if np.isscalar(ts):
+            ts = np.ones((1), dtype=np.uint32) * ts
+        value = np.int16(dataImu[:, 1] & 0xFFFF)
+        dataImu[:, 1] >>= 16
+        sensor = np.uint8(dataImu[:, 1] & 0x0F)
+        dataImu[:, 1] >>= 6
+        ch  = np.uint8(dataImu[:, 1] & 0x01)
+        outDict['imuSamples'] = {
                 'ts': ts,
                 'ch': ch,
-                'x': x,
-                'y': y,
-                'pol': pol
-            }
-    else:
-        dvsOut = None
-    return dvsOut, samplesOut
+                'sensor': sensor,
+                'value': value}
+    
+    if np.any(skinBool):
+        dataSkin = data[skinBool, :]
+        ts = np.uint32(dataSkin[:, 0])
+        if np.isscalar(ts):
+            ts = np.ones((1), dtype=np.uint32) * ts
+        polarity = np.bool_(dataSkin[:, 1] & 0x01)
+        dataSkin[:, 1] >>= 1
+        taxel = np.uint16(dataSkin[:, 1] & 0x3FF)
+        dataSkin[:, 1] >>= 12
+#        crossBase = np.uint8(dataSkin[:, 1] & 0x01)
+        dataSkin[:, 1] >>= 3
+        bodyPart = np.uint8(dataSkin[:, 1] & 0x07)
+        dataSkin[:, 1] >>= 6
+        side = np.uint8(dataSkin[:, 1] & 0x01)
+#        dataSkin[:, 1] >>= 1
+#        eventType = np.uint8(dataSkin[:, 1] & 0x01)
+        outDict['skinEvents'] = {
+                'ts': ts,
+                'side': side,
+                'bodyPart': bodyPart,
+                'taxel': taxel,
+                'pol': polarity}
+    
+    if np.any(earBool):
+        dataEar = data[earBool, :]
+        ts = np.uint32(dataEar[:, 0])
+        if np.isscalar(ts):
+            ts = np.ones((1), dtype=np.uint32) * ts
+        polarity = np.bool_(dataEar[:, 1] & 0x01)
+        dataEar[:, 1] >>= 1
+        frequencyChannel = np.uint8(dataEar[:, 1] & 0x7F)
+        dataEar[:, 1] >>= 7
+        xsoType = np.uint8(dataEar[:, 1] & 0x01)
+        dataEar[:, 1] >>= 1
+        auditoryModel = np.uint8(dataEar[:, 1] & 0x01)
+        dataEar[:, 1] >>= 3
+        itdNeuronIds = np.uint8(dataEar[:, 1] & 0x7F)
+        dataEar[:, 1] >>= 10
+        channel = np.uint8(dataEar[:, 1] & 0x01)
+        outDict['ear'] = {
+                'ts': ts,
+                'ch': channel,
+                'itdNeuronIds': itdNeuronIds,
+                'auditoryModel': auditoryModel,
+                'xsoType': xsoType,
+                'freq': frequencyChannel,
+                'pol': polarity}
+    return outDict
+
 
 def getOrInsertDefault(inDict, arg, default):
     # get an arg from a dict.
@@ -170,22 +248,6 @@ def getOrInsertDefault(inDict, arg, default):
         inDict[arg] = default
     return value
 
-def flowFromBitsToFloat(flowBits):
-    '''
-    Convert FLOW events from bits to float
-    '''
-    flowFloat = np.ndarray(len(flowBits))
-    for i, bit in enumerate(flowBits):
-        test = bitsToFloat(bit)
-        flowFloat[i] = test
-    return flowFloat
-
-def bitsToFloat(b):
-    '''
-    Convert a number in bits to float
-    '''
-    s = struct.pack('>I', b)
-    return struct.unpack('>f', s)[0]
 
 def samplesToImu(inDict, **kwargs):
     '''
@@ -193,17 +255,12 @@ def samplesToImu(inDict, **kwargs):
     Assume these are IMU samples, and compile them (up to) 10 at a time.
     Output is ts, acc, angV, temp and mag
     'Sensor' is defined as:
-    0: - (negative) Accel Y
-    1: Accel X
-    2: Accel Z
-    3: - (negative) Gyro Y
-    4: Gyro X
-    5: Gyro Z
-    6: Temperature
-    7: - (negative) Mag Y
-    8: Mag X
-    9: Mag Z
-    For the IMU on STEFI, (which is this one ICM-20948):
+        0: - (negative) Accel Y     1: Accel X     2: Accel Z
+        3: - (negative) Gyro Y      4: Gyro X      5: Gyro Z
+        6: Temperature
+        7: - (negative) Mag Y       8: Mag X       9: Mag Z
+    
+    For the IMU on STEFI, (which is: ICM-20948):
     gyro full scale is +/-2000 degrees per second,
     accelerometer full scale is +/-2 g.
     temp - 333.87 - but does it zero at 0K or at room temperature? (+21deg)
@@ -222,7 +279,7 @@ def samplesToImu(inDict, **kwargs):
     valueAll = inDict['value']
     wrapIds = np.where((sensorAll[1:]-sensorAll[:-1])<1)[0]
     numImu = len(wrapIds) + 1
-    tsOut = np.zeros((numImu), dtype=np.uint32)
+    tsOut = np.zeros((numImu), dtype=np.float64)
     acc = np.zeros((numImu, 3), dtype=np.int16)
     angV = np.zeros((numImu, 3), dtype=np.int16)
     temp = np.zeros((numImu, 1), dtype=np.int16)
@@ -267,8 +324,149 @@ def samplesToImu(inDict, **kwargs):
             }
     return outDict
 
-def importIitYarpBinaryDataLog(**kwargs):
 
+'''
+Similarly to imu data, skin samples are delivered in batches with each of the
+192 taxels sampled once in a repeating pattern, each with its own timestamp. 
+Group these together into mult-dimensional samples each with a single timestamp.
+We use the observation that groups start with taxel 213 to simplify this.
+TODO: Use a more robust method of identifying groups.
+We reject any data that doesn't form a complete group.
+taxelOrder is included so that the ordered samples can later be mapped to their respective addresses. 
+'''
+def groupSkinSamples(inDict):
+    wrapIds = np.where((inDict['taxel'] == 213))[0]
+    pressure = inDict['value'][wrapIds[0]:wrapIds[-1]].reshape(-1, 192)
+    taxelOrder = inDict['taxel'][wrapIds[0]:wrapIds[1]]
+    ts = inDict['ts'][wrapIds[0]:wrapIds[-1]:192]
+    return {'ts': ts,
+            'pressure': pressure,
+            'taxelOrder': taxelOrder}
+
+'''
+For a batch of events for a given dataType, and the container of all events for
+that dataType so far, add the batch to the container.
+The first batch for each data type gets used as the model to which all further 
+batches get added.
+A container is a dict of numpy arrays. As these arrays need to be expanded to
+fit the new data, they are doubled in size. This limits to O(log(n)) the
+number of times we need to resize the arrays and it limits to nx4 the amount of
+memory used. An alternative would be to build lists and then convert to numpy
+at the end.
+'''
+def appendBatch(mainDict, batch):
+    if batch is None:
+        return mainDict
+    numEventsBatch = len(batch['ts'])
+    if mainDict is None:
+        batch['numEvents'] = numEventsBatch
+        return batch
+    # Check if the main array has enough free space for this batch
+    sizeOfMain = len(mainDict['ts'])
+    numEventsMain = mainDict['numEvents']
+    while numEventsBatch + numEventsMain > sizeOfMain:
+        for fieldName in mainDict.keys():
+            if fieldName != 'numEvents':
+                # Double the size of the array
+                mainDict[fieldName] = np.append(mainDict[fieldName], np.empty_like(mainDict[fieldName]), axis=0)
+        sizeOfMain *= 2
+    # Add the batch into the main array
+    for fieldName in batch.keys():
+        if mainDict[fieldName].ndim == 2:
+            mainDict[fieldName][numEventsMain:numEventsMain + numEventsBatch, :] = \
+            batch[fieldName]
+        else:
+            mainDict[fieldName][numEventsMain:numEventsMain + numEventsBatch] = \
+            batch[fieldName]
+    mainDict['numEvents'] = numEventsMain + numEventsBatch
+    return mainDict
+
+
+def cropArraysToNumEvents(inDict):
+    if inDict is None:
+        return None
+    numEvents = inDict.pop('numEvents')
+    for fieldName in inDict.keys():
+        inDict[fieldName] = inDict[fieldName][:numEvents]
+    return inDict
+
+'''
+    Zero timestamps.
+    Split by channel: The iit yarp format assumes that the channel bit
+    corresponds to 'left' and 'right' sensors, so it's handled explicitly here
+'''
+def globalPostProcessing(inDict, **kwargs):
+    # zero time by default (keeping the offset)
+    if getOrInsertDefault(kwargs, 'zeroTimestamps', True):
+        zeroTimestampsForAChannel(inDict)
+    # Split into left and right channels
+    # Allowing previously used 'split_stereo' for backwards compatibility
+    splitByChannel = kwargs.get('splitChannel', kwargs.get('split_stereo', True))
+    if splitByChannel:
+        dataTypes = list(inDict.keys())
+        channels = {}
+        for chIdx, chName in enumerate(['left', 'right']):
+            chDict = {}
+            for dataType in dataTypes:
+                dataForChannel = None
+                if 'ch' in inDict[dataType]:
+                    dataForChannel = selectByLabel(inDict[dataType], 'ch', chIdx)
+                elif 'side' in inDict[dataType]:
+                    dataForChannel = selectByLabel(inDict[dataType], 'side', chIdx)
+                if dataForChannel is not None:
+                    chDict[dataType] = dataForChannel
+            if any(chDict):
+                channels[chName] = chDict
+        for dataType in dataTypes:
+            if 'ch' in inDict[dataType] or 'side' in inDict[dataType]:
+                del inDict[dataType]
+        if any(inDict):
+            channels['general'] = inDict
+    else:
+        channels = {'all': inDict}
+    # Construct the output dict
+    outDict = {
+        'info': kwargs,
+        'data': channels
+        }
+    outDict['info']['fileFormat'] = 'iityarp'
+    return outDict
+
+'''
+Having imported data from the either a datadumper log or a bin file, 
+carry out common post-processing steps:
+    eliminate dict keys which have no data
+    IMU special handling: convert samples to IMU (because up to 10 consecutive
+                                        samples define single imu read-out)
+    Unwrap timestamps and convert to seconds
+    Then there is a call to global post processing for splitting by channel
+    timestamp zeroing and formation as a top-level container.
+'''
+def importPostProcessing(inDict, **kwargs):
+    dataTypes = list(inDict.keys()) # List out the datatypes before this loop
+                                    # because the loop changes the dict
+    for dataType in dataTypes:
+        # Eliminate dataTypes which didn't have any events
+        if inDict[dataType] is None:
+            del inDict[dataType]
+        else:
+        # Iron out any time-wraps which occurred
+            inDict[dataType]['ts'] = unwrapTimestamps(inDict[dataType]['ts'],
+                                    **kwargs) * 0.00000008 # Convert to seconds
+            # Special handling for imu data
+            if dataType == 'imuSamples':
+                if kwargs.get('convertSamplesToImu', True):
+                    inDict['imu'] = samplesToImu(inDict.pop('imuSamples'), **kwargs)
+                else:
+                    inDict['sample'] = inDict.pop('imuSamples')
+                    # TODO: The name "sample" is too vague
+            # Special handling for imu data
+            if dataType == 'skinSamples':
+                inDict['skinSamples'] = groupSkinSamples(inDict['skinSamples'])
+    return globalPostProcessing(inDict, **kwargs)
+
+
+def importIitYarpBinaryDataLog(**kwargs):
     importFromByte = kwargs.get('importFromByte', 0)
     importMaxBytes = kwargs.get('importMaxBytes')
     if importMaxBytes is not None:
@@ -282,157 +480,56 @@ def importIitYarpBinaryDataLog(**kwargs):
             events = file.read()
         events = np.frombuffer(events, np.uint32)
         events = events.reshape((-1, 2))
-        dvs, samples = decodeEvents(events)
+        outDict = decodeEvents(events)
         if file.read(1) is None:
             kwargs['importedToByte'] = 'EOF'
         else:
-            kwargs['importedToByte'] = file.tell() - 2 # - 2 also compensates for the small read-ahead just performed to test EOF
-    if kwargs.get('split_stereo', True):
-        return importPostProcessing(dvs, samples, dvsLbl=None, flow=None, **kwargs)
-    else:
-        return importPostProcessingNoSplit(dvs, samples, dvsLbl=None, flow=None, **kwargs)
-    
-# Sample is an intermediate data type - later it gets converted to IMU etc
-def createDataTypeSample():
-    sizeOfArray = 1024
-    return {
-        'ts': np.zeros((sizeOfArray), dtype=np.uint32),
-        'ch': np.zeros((sizeOfArray), dtype=np.uint8),
-        'sensor': np.zeros((sizeOfArray), dtype=np.uint8),
-        'value': np.zeros((sizeOfArray), dtype=np.int16),
-        'numEvents': 0
-    }
-
-def createDataTypeDvs():
-    sizeOfArray = 1024
-    return {
-        'ts': np.zeros((sizeOfArray), dtype=np.uint32),
-        'ch': np.zeros((sizeOfArray), dtype=np.uint8),
-        'x': np.zeros((sizeOfArray), dtype=np.uint16),
-        'y': np.zeros((sizeOfArray), dtype=np.uint16),
-        'pol': np.zeros((sizeOfArray), dtype=np.bool),
-        'numEvents': 0
-        }
-
-def createDataTypeDvsLbl():
-    dvs = createDataTypeDvs()
-    sizeOfArray = len(dvs['ts'])
-    dvs['lbl'] = np.zeros((sizeOfArray), dtype=np.int64)
-    return dvs
-
-def createDataTypeDvsFlow():
-    dvs = createDataTypeDvs()
-    sizeOfArray = len(dvs['ts'])
-    dvs['vx'] = np.zeros((sizeOfArray), dtype=np.uint32) # These end up as floats, but they start as ints and are converted in batch later
-    dvs['vy'] = np.zeros((sizeOfArray), dtype=np.uint32) # These end up as floats, but they start as ints and are converted in batch later
-    return dvs
-
-def appendBatch(mainDict, batch):
-    if batch is None: return mainDict
-    # Check if the main array has enough free space for this batch
-    sizeOfMain = len(mainDict['ts'])
-    numEventsInMain = mainDict['numEvents']
-    numEventsInBatch = len(batch['ts'])
-    while numEventsInBatch + numEventsInMain > sizeOfMain:
-        for fieldName in mainDict.keys():
-            if fieldName != 'numEvents':
-                # Double the size of the array
-                mainDict[fieldName] = np.append(mainDict[fieldName], np.empty_like(mainDict[fieldName]))
-        sizeOfMain *= 2
-    # Add the batch into the main array
-    for fieldName in batch.keys():
-        mainDict[fieldName][numEventsInMain:numEventsInMain + numEventsInBatch] = \
-            batch[fieldName]
-    mainDict['numEvents'] = numEventsInMain + numEventsInBatch
-    return mainDict
-
-def cropArraysToNumEvents(inDict):
-    numEvents = inDict.pop('numEvents')
-    for fieldName in inDict.keys():
-        inDict[fieldName] = inDict[fieldName][:numEvents]
+            kwargs['importedToByte'] = file.tell() - 2 
+            # - 2 compensates for the small read-ahead just performed to test EOF
+    return importPostProcessing(outDict, **kwargs)
 
 '''
-Having imported data from the either a datadumper log or a bin file, 
-carry out common post-processing steps: 
-    convert samples to IMU (etc)
-    split by channel
-    unwrap timestamps
+Some files from the 'Old MTB' (As of 2020_12 mounted on iCub) where skin is dumped
+it creates a quite different bottle format :
+    bottleNumber(int - actually alway -1) ts(float already in seconds) sample1(float) sample2(float) ...
 '''
-def importPostProcessing(dvs, samples, dvsLbl=None, dvsFlow=None, **kwargs):
-    '''
-    Split by channel: The iit yarp format assumes that the channel bit 
-    corresponds to 'left' and 'right' sensors, so it's handled explicitly here
-    '''
-    channels = {}
-    for ch in [0, 1]:
-        chDict = {}
-        dvsCh = selectByLabel(dvs, 'ch', ch)
-        if dvsCh:
-            chDict['dvs'] = dvsCh
-        if dvsLbl:
-            dvsLblCh = selectByLabel(dvsLbl, 'ch', ch)
-            if dvsLblCh:
-                chDict['dvslbl'] = dvsLblCh
-        samplesCh = selectByLabel(samples, 'ch', ch) if samples is not None else None
-        if samplesCh:
-            if kwargs.get('convertSamplesToImu', True):
-                chDict['imu'] = samplesToImu(samplesCh, **kwargs)
-            else:
-                chDict['sample'] = samplesCh
-        if dvsFlow:
-            dvsFlowCh = selectByLabel(dvsFlow, 'ch', ch)
-            if dvsFlowCh:
-                chDict['flow'] = dvsFlowCh
-                chDict['flow']['vx'] = flowFromBitsToFloat(chDict['flow']['vx'])
-                chDict['flow']['vy'] = flowFromBitsToFloat(chDict['flow']['vy'])
-        if any(chDict):
-            for dataType in chDict:
-                chDict[dataType]['ts'] = unwrapTimestamps(chDict[dataType]['ts'], **kwargs) * 0.00000008 # Convert to seconds
-
-            if getOrInsertDefault(kwargs, 'zeroTimestamps', True):
-                zeroTimestampsForAChannel(chDict)
-            if ch == 0:
-                channels['left'] = chDict
-            else:
-                channels['right'] = chDict
-    # Construct the output dict
-    outDict = {
-        'info': kwargs,
-        'data': channels
-        }
-    outDict['info']['fileFormat'] = 'iityarp'
-    return outDict
-
-def importPostProcessingNoSplit(dvs, samples, dvsLbl=None, dvsFlow=None, **kwargs):
-    channels = {}
-    chDict={}
-    if dvs:
-        chDict['dvs'] = dvs
-    if dvsLbl:
-        chDict['dvslbl'] = dvsLbl
-    if samples:
-        if kwargs.get('convertSamplesToImu', True):
-            chDict['imu'] = samplesToImu(samples, **kwargs)
-        else:
-            chDict['sample'] = samples
-    if dvsFlow:
-        chDict['flow'] = dvsFlow
-        chDict['flow']['vx'] = flowFromBitsToFloat(chDict['flow']['vx'])
-        chDict['flow']['vy'] = flowFromBitsToFloat(chDict['flow']['vy'])
-    if any(chDict):
-        for dataType in chDict:
-            chDict[dataType]['ts'] = unwrapTimestamps(chDict[dataType]['ts'], **kwargs) * 0.00000008 # Convert to seconds
-
-        if getOrInsertDefault(kwargs, 'zeroTimestamps', True):
-            zeroTimestampsForAChannel(chDict)
-    channels['stereo'] = chDict
-    # Construct the output dict
-    outDict = {
-        'info': kwargs,
-        'data': channels
-        }
-    outDict['info']['fileFormat'] = 'iityarp'
-    return outDict
+def importIitRawSkinSamples(**kwargs):
+    importFromByte = kwargs.get('importFromByte', 0)
+    importToByte = kwargs.get('importMaxBytes')
+    if importToByte is not None:
+        importToByte += importFromByte
+    with open(kwargs['filePathOrName'], 'r') as file:
+        file.seek(importFromByte)
+        importedToByte = 'EOF' # default if the following loop exits normally
+        line = file.readline()
+        currentPointer = 0
+        skinSamples = None
+        while line:
+            if importToByte is not None:
+                if file.tell() > importToByte:
+                    importedToByte = currentPointer - 1
+                    break
+                else:
+                    currentPointer = file.tell()
+            try:
+                numbers = line.split(' ')
+                numSamples = len(numbers) - 2
+                # TODO: Later, we might generalise the number of channels.
+                assert numSamples == 192
+                ts = float(numbers[1])
+                samples = np.array(numbers[2:], dtype=np.float64)[np.newaxis, :]
+                newSample = {'ts': np.ones((1), dtype = np.float64) * ts,
+                             'pressure': samples}
+                skinSamples = appendBatch(skinSamples, newSample)
+            except ValueError: # sometimes finding malformed packets at the end of files - ignoring
+                print('Failed to interpret a line')
+                line = file.readline()
+                continue
+            line = file.readline()
+    skinSamples['ts'] = unwrapTimestamps(skinSamples['ts']) # will this ork on float values?
+    outDict = {'skinSamples': cropArraysToNumEvents(skinSamples)}
+    kwargs['importedToByte'] = importedToByte
+    return globalPostProcessing(outDict, **kwargs)
 
 
 def importIitYarpDataLog(**kwargs):
@@ -440,16 +537,22 @@ def importIitYarpDataLog(**kwargs):
     patternForVicon = re.compile('(\d+) (\d+\.\d+) \((.*)\)')
     with open(kwargs['filePathOrName'], 'r') as inFile:
         content = inFile.readline() # Look at first line of file
-    found = patternForVicon.findall(content)
-    if found:
+    if patternForVicon.findall(content):
         print('Yarp vicon dumper pattern found - passing this file to importVicon function')
         return importIitVicon(**kwargs)
-
+    patternForRawSkinSamples = re.compile('-1 (\d+\.\d+) (\d+\.\d+)')
+    if patternForRawSkinSamples.findall(content):
+        print('Pattern found seems to be a raw dump of analogue skin samples')
+        return importIitRawSkinSamples(**kwargs)
     # Create dicts for each possible datatype
-    dvs = createDataTypeDvs()
-    dvsLbl = createDataTypeDvsLbl()
-    dvsFlow = createDataTypeDvsFlow()
-    samples = createDataTypeSample() # Sample is an intermediate datatype - later it gets converted to IMU etc
+    dvs = None
+    dvsLbl = None
+    dvsFlow = None
+    imuSamples = None # Imu Sample is an intermediate datatype - later it gets converted to IMU etc
+    skinEvents = None
+    skinSamples = None
+    ear = None
+    aps = None
     pattern = re.compile('(\d+) (\d+\.\d+) ([A-Z]+) \((.*)\)')
     importFromByte = kwargs.get('importFromByte', 0)
     importToByte = kwargs.get('importMaxBytes')
@@ -458,7 +561,6 @@ def importIitYarpDataLog(**kwargs):
     with open(kwargs['filePathOrName'], 'r') as file:
         file.seek(importFromByte)
         importedToByte = 'EOF' # default if the following loop exits normally
-        # We are not using 'for' iteration because it's aincompatible with the tell() method
         line = file.readline()
         currentPointer = 0
         while line:
@@ -469,53 +571,78 @@ def importIitYarpDataLog(**kwargs):
                 else:
                     currentPointer = file.tell()
             found = pattern.match(line)
-            if found is None:
-                line = file.readline()
-                continue
             # The following values would be useful for indexing the input file:
             #bottlenumber = np.uint32(found[1])
             #timestamp = np.float64(found[2])
             bottleType = found[3]
-            if bottleType not in ['AE', 'IMUS', 'LAE', 'FLOW']:
-                print(bottleType)
+            if bottleType not in ['AE', 'IMUS', 'LAE', 'FLOW', 'EAR', 'SKS', 'SKE']:
+                print('Unknown bottle type: ' + bottleType)
                 line = file.readline()
                 continue
             try:
                 events = np.array(found[4].split(' '), dtype=np.uint32)
+                '''
+                The following block handles unusual bottle format for labelled
+                events and flow events, which all end up being treated as 
+                'dvs' type events. In those cases there are extra words in
+                the bottle for each event.
+                '''
                 if bottleType == 'LAE':
                     numEventsInBatch = int(len(events) / 3)
                     events = events.reshape(numEventsInBatch, 3)
-                    # TODO: finish handling this case
-                    dvsBatch, samplesBatch = decodeEvents(events[:, :2])
+                    outDict = decodeEvents(events[:, :2], **kwargs)
+                    dvsBatch = outDict['dvs']
                     dvsBatch['lbl'] = events[:, 2]
-                    appendBatch(dvsLbl, dvsBatch)
+                    dvsLbl = appendBatch(dvsLbl, dvsBatch)
                 elif bottleType == 'FLOW':
                     numEventsInBatch = int(len(events) / 4)
                     events = events.reshape(numEventsInBatch, 4)
-                    dvsBatch, samplesBatch = decodeEvents(events[:, :2])
-                    dvsBatch['vx'] = events[:, 2]
-                    dvsBatch['vy'] = events[:, 3]
-                    appendBatch(dvsFlow, dvsBatch)
-                else: # bottleType in ['AE', 'IMUS']
+                    outDict = decodeEvents(events[:, :2], **kwargs)
+                    dvsBatch = outDict['dvs']
+                    dvsBatch['vx'] = events[:, 2].view(dtype=np.float32)
+                    dvsBatch['vy'] = events[:, 3].view(dtype=np.float32)
+                    dvsFlow = appendBatch(dvsFlow, dvsBatch)
+                elif bottleType == 'SKS':
+                    ''' Skin samples are encoded with 4 words:
+                        [ts, address, ts, analogue_sample(least-sig. 16 bits)]
+                        The address is encoded the same as for skin events
+                        we ignore the second timestamp
+                    '''
+                    numEventsInBatch = int(len(events) / 4)
+                    events = events.reshape(numEventsInBatch, 4)
+                    outDict = decodeEvents(events, **kwargs)
+                    skinSampleBatch = outDict.pop('skinEvents') # pop these so they don't get treated as skin events, below
+                    skinSampleBatch['value'] = np.mod(events[:, 3], 2**16)
+                    skinSamples = appendBatch(skinSamples, skinSampleBatch)
+                else: # bottleType in ['AE', 'IMUS', 'SKE', 'EAR', 'APS']
                     numEventsInBatch = int(len(events) / 2)
                     events = events.reshape(numEventsInBatch, 2)
-                    dvsBatch, samplesBatch = decodeEvents(events[:, :2])
-                    appendBatch(dvs, dvsBatch)
-                appendBatch(samples, samplesBatch)
+                    outDict = decodeEvents(events[:, :2], **kwargs)
+                    dvsBatch = outDict['dvs']
+                    dvs = appendBatch(dvs, dvsBatch)
+                    imuSamples = appendBatch(imuSamples, outDict['imuSamples'])
+                    ear = appendBatch(ear, outDict['ear'])
+                    skinEvents = appendBatch(skinEvents, outDict['skinEvents'])
+                    aps = appendBatch(aps, outDict['aps'])
             except ValueError: # sometimes finding malformed packets at the end of files - ignoring
                 line = file.readline()
                 continue
             line = file.readline()
-
     # If importedToByte is not defined then we reached the end of the file
-    delattr(decodeEvents, "is24bitCodec")
     # Crop arrays to number of events
-    cropArraysToNumEvents(dvs)
-    cropArraysToNumEvents(dvsLbl)
-    cropArraysToNumEvents(samples)
-    cropArraysToNumEvents(dvsFlow)
+    outDict = {
+        'dvs': cropArraysToNumEvents(dvs),
+        'dvsLbl': cropArraysToNumEvents(dvsLbl),
+        'flow': cropArraysToNumEvents(dvsFlow), # TODO: 'flow' is a poor name, considering we also have dense flow maps
+        'imuSamples': cropArraysToNumEvents(imuSamples), # Imu Sample is an intermediate datatype - later it gets converted to IMU etc
+        'skinEvents': cropArraysToNumEvents(skinEvents),
+        'skinSamples': cropArraysToNumEvents(skinSamples),
+        'ear': cropArraysToNumEvents(ear),
+        'aps': cropArraysToNumEvents(aps),
+        }
     kwargs['importedToByte'] = importedToByte
-    return importPostProcessing(dvs, samples, dvsLbl=dvsLbl, dvsFlow=dvsFlow, **kwargs)
+    return importPostProcessing(outDict, **kwargs)
+
 
 # From the info.log we want the time that the channel connected; we assume this is the first decimal found
 def importIitYarpInfoLog(**kwargs):
@@ -529,6 +656,7 @@ def importIitYarpInfoLog(**kwargs):
     if found:
         tsOffset = float(found[0])
         return tsOffset
+
 
 def importIitYarpRecursive(**kwargs):
     '''
@@ -565,6 +693,7 @@ def importIitYarpRecursive(**kwargs):
         importedDicts[-1]['info']['tsOffsetFromInfo'] = tsOffset
     return importedDicts
 
+
 def importIitYarp(**kwargs):
     importedDicts = importIitYarpRecursive(**kwargs)
     if kwargs.get('zeroTime', kwargs.get('zeroTimestamps', True)):
@@ -574,35 +703,4 @@ def importIitYarp(**kwargs):
     if len(importedDicts) == 1:
         importedDicts = importedDicts[0]
     return importedDicts
-
-#%% LEGACY CODE
-# Import functions from marco monforte, for reference
-'''
-   def decode_skinEvents(self, data):
-        # Events are encoded as 32 bits with polarity(p), taxel(t), cross_base(c),
-        # body_part(b), side(s), type(T) and skin(S) as shown below. Reserved bits are represented with (R)
-
-        # 0000 0000 STsR RRbb bRRc RRttt tttt tttp
-
-        if data[-1,0] == 0:
-            data = np.delete(data, -1)
-
-        timestamps = data[:, 0] & ~(0x1 << 31)
-
-        polarity = data[:, 1] & 0x01
-        data[:, 1] >>= 1
-        taxel = data[:, 1] & 0x3FF
-        data[:, 1] >>= 12
-        cross_base = data[:, 1] & 0x01
-        data[:, 1] >>= 3
-        body_part = data[:, 1] & 0x07
-        data[:, 1] >>= 6
-        side = data[:, 1] & 0x01
-        data[:, 1] >>= 1
-        type = data[:, 1] & 0x01
-        data[:, 1] >>= 1
-        skin = data[:, 1] & 0x01
-
-        return np.vstack([timestamps, polarity, taxel, cross_base, body_part, side, type, skin]).T.astype(np.float)
-'''
 

--- a/bimvee/importIitYarp.py
+++ b/bimvee/importIitYarp.py
@@ -540,7 +540,7 @@ def importIitYarpDataLog(**kwargs):
     if patternForVicon.findall(content):
         print('Yarp vicon dumper pattern found - passing this file to importVicon function')
         return importIitVicon(**kwargs)
-    patternForRawSkinSamples = re.compile('-1 (\d+\.\d+) (\d+\.\d+)')
+    patternForRawSkinSamples = re.compile('(\d+) (\d+\.\d+) (\d+\.\d+)')
     if patternForRawSkinSamples.findall(content):
         print('Pattern found seems to be a raw dump of analogue skin samples')
         return importIitRawSkinSamples(**kwargs)

--- a/bimvee/importIitYarp.py
+++ b/bimvee/importIitYarp.py
@@ -57,9 +57,9 @@ recommended, by saving e.g. pngs to a folder - support the latter
 There are 2 dvs codecs: 20-bit and 24-bit. 24-bit is assumed unless kwarg
 "codec" = "20bit" is received
 
-This document gives more principled and complete info for event decoding specifically from iCub:
-https://github.com/event-driven-robotics/ed-skin/blob/master/docs/technotes/TN001-Peripherals-to-HPU-Data-Encoding_rev1.pdf
-
+More information about event decoding are available in the event-driven reposi-
+tory on GitHub:
+    https://github.com/robotology/event-driven/blob/master/documentation/eventcodecs.md
 """
 
 # %%


### PR DESCRIPTION
extended to handle: SKS, SKE, EAR type bottles,
extended to handle raw dumps of skin samples
splitByChannel (left vs right) generalised over different dataTypes.
flow-value float conversion simplified with numpy.view
create<dataype> functions removed - first batch serves as pattern for all subsequent batches.
import post processing functions with and without split handling merged;
global post processing separated out from dataType-specific post processing.
20-bit dvs data handling now depends on 'codec' kwarg rather than looking at data patterns (since former method was not guaranteed to work for all data).