### PR TITLE
added parameter for clock rate

### DIFF
--- a/bimvee/exportIitYarp.py
+++ b/bimvee/exportIitYarp.py
@@ -177,9 +177,13 @@ def encodeEvents24Bit(ts, x, y, pol, ch=None, **kwargs):
     # 0000 0000 tcrr yyyy yyyy rrxx xxxx xxxp    (r = reserved)
     # t = 0 to indicate events
     # Ignoring channel though
-    isGen1 = (x < 346).all() and (y < 260).all()
-    clock_time = 0.00000008 if isGen1 else 0.000001
-    ts = ts / clock_time
+    clock_period = kwargs.get('clock')
+    if clock_period == None:
+        clock_period = 1 / 1e6
+    else:
+        clock_period = clock_period / 1e9
+
+    ts = ts / clock_period
     ts = ts.astype(np.uint32)  # Timestamp wrapping occurs here
     ts = np.expand_dims(ts, 1)
     x = x.astype(np.uint32)

--- a/bimvee/importIitYarp.py
+++ b/bimvee/importIitYarp.py
@@ -485,10 +485,14 @@ def importPostProcessing(inDict, **kwargs):
             del inDict[dataType]
         else:
             # Iron out any time-wraps which occurred and convert to seconds
-            isGen1 = (inDict[dataType]['x'] < 346).all() and (inDict[dataType]['y'] < 260).all()
-            clock_time = 0.00000008 if isGen1 else 0.000001
+            clock_period = kwargs.get('clock')
+            if clock_period == None:
+                clock_period = 1 / 1e6
+            else:
+                clock_period = clock_period / 1e9
+
             inDict[dataType]['ts'] = unwrapTimestamps(inDict[dataType]['ts'],
-                                                      **kwargs) * clock_time
+                                                      **kwargs) * clock_period
             # Special handling for imu data
             if dataType == 'imuSamples':
                 if kwargs.get('convertSamplesToImu', True):


### PR DESCRIPTION
removed the assumption that the tick rate of the clock is determined from sensor resolution. instead the clock period can be set as a parameter `clock=80` for 80 ns and `clock=1000` for 1 us. If nothing is provided 1 us will be used.