### PR TITLE
allow seaborns to be an optional dependency

### DIFF
--- a/bimvee/plotFlow.py
+++ b/bimvee/plotFlow.py
@@ -21,14 +21,6 @@ IMU samples contained.
 """
 import os
 import matplotlib.pyplot as plt
-import seaborn as sns
-
-sns.set(palette="colorblind")
-
-# Color Palette for Color Blindness
-zesty_palette     = ['#F5793A', '#A95AA1', '#85C0F9', '#0F2080']
-retro_palette     = ['#601A4A', '#EE442F', '#63ACBE', '#F9F4EC']
-corporate_palette = ['#8DB8AD', '#EBE7E0', '#C6D4E1', '#44749D']
 
 #-----------------------------------------------------------------------------------------------------
 def plotFlow(flowDict, fig_path=None, fig_name=None, fig_subtitle=None):
@@ -92,6 +84,14 @@ def plotFlowDistribution(flowDict, fig_path=None, fig_name=None, fig_subtitle=No
         fig_name {string} -- name of the generated figure (default: {None})
         fig_subtitle {string} -- figure sub-title (default: {None})
     """
+    import seaborn as sns
+    
+    sns.set(palette="colorblind")
+    
+    # Color Palette for Color Blindness
+    zesty_palette     = ['#F5793A', '#A95AA1', '#85C0F9', '#0F2080']
+    retro_palette     = ['#601A4A', '#EE442F', '#63ACBE', '#F9F4EC']
+    corporate_palette = ['#8DB8AD', '#EBE7E0', '#C6D4E1', '#44749D']
     fig = plt.figure(figsize=(14.0, 10.0))
     if isinstance(fig_subtitle, str):
         fig.suptitle("FLOW Events Distribution\n" + fig_subtitle, fontsize=20, fontweight='bold')

--- a/bimvee/plotImu.py
+++ b/bimvee/plotImu.py
@@ -19,14 +19,6 @@ IMU samples contained.
 """
 import os, sys
 import matplotlib.pyplot as plt
-import seaborn as sns
-
-sns.set(palette="colorblind")
-
-# Color Palette for Color Blindness
-zesty_palette     = ['#F5793A', '#A95AA1', '#85C0F9', '#0F2080']
-retro_palette     = ['#601A4A', '#EE442F', '#63ACBE', '#F9F4EC']
-corporate_palette = ['#8DB8AD', '#EBE7E0', '#C6D4E1', '#44749D']
 
 #-----------------------------------------------------------------------------------------------------
 def plotImu(inDict, **kwargs):
@@ -83,6 +75,14 @@ def plotImu(inDict, **kwargs):
 
 #-----------------------------------------------------------------------------------------------------
 def plotImuDistribution(imuDict, unitIMU='FPGA', fig_path=None, fig_name=None, fig_subtitle=None):
+    import seaborn as sns
+    
+    sns.set(palette="colorblind")
+    
+    # Color Palette for Color Blindness
+    zesty_palette     = ['#F5793A', '#A95AA1', '#85C0F9', '#0F2080']
+    retro_palette     = ['#601A4A', '#EE442F', '#63ACBE', '#F9F4EC']
+    corporate_palette = ['#8DB8AD', '#EBE7E0', '#C6D4E1', '#44749D']
     """
     Plot the distribution of the IMU data in imuDict. If specified, save the
     generated figure as fig_name.png at the location defined by fig_path.


### PR DESCRIPTION
plotFlow and plotImu contain functions which use seaborns. The import of seaborns is moved inside these functions, meaning that to use the generic plot functions you don't need to install seaborn.