### PR TITLE
Fix with_ts detection in importIitYarpDataLog

### DIFF
--- a/bimvee/filter.py
+++ b/bimvee/filter.py
@@ -21,32 +21,85 @@ within a certain spatio-temporal window.
 
 import numpy as np
 
-def filter_spatiotemporal_single(events, time_window=0.05, neighbourhood=1):
-    xs = events['x']
-    ys = events['y']
-    ts = events['ts']
-    pol = events['pol']
+# def filter_spatiotemporal_single(events, time_window=0.05, neighbourhood=1):
+#     xs = events['x']
+#     ys = events['y']
+#     ts = events['ts']
+#     pol = events['pol']
  
+#     offset_neg = neighbourhood
+#     offset_pos = neighbourhood + 1
+    
+#     xs = xs + neighbourhood
+#     ys = ys + neighbourhood
+#     keep = np.zeros_like(ts, dtype=bool)
+#     last_ts = np.full((np.max(ys) + neighbourhood * 2, 
+#                        np.max(xs) +  + neighbourhood * 2), 
+#                       -np.inf)
+#     for i, (x, y, t) in enumerate(zip(xs, ys, ts)):
+#         if t - last_ts[y, x] <= time_window:
+#             keep[i] = True
+#         last_ts[y - offset_neg : y + offset_pos, 
+#                 x - offset_neg : x + offset_pos] = t #update
+#     return {
+#         'x' : events['x'][keep],
+#         'y' : events['y'][keep],
+#         'ts' : events['ts'][keep],
+#         'pol' : events['pol'][keep],
+#         }
+
+
+
+def filter_spatiotemporal_single(events, time_window=0.01, neighbourhood=0):
+    """
+    Filters DVS events using a spatio-temporal consistency check.
+    
+    An event is kept only if a previous event occurred in its spatial neighborhood
+    within a defined time window.
+
+    Parameters:
+        events (dict): Dictionary with 'x', 'y', 'ts', 'pol'.
+        time_window (float): Maximum time difference (in seconds) for an event to be considered consistent.
+        neighbourhood (int): Number of pixels in each direction for spatial neighborhood.
+
+    Returns:
+        dict: Filtered events.
+    """
+    xs = np.array(events['x'])
+    ys = np.array(events['y'])
+    ts = np.array(events['ts'])
+
+    # Shift coordinates to allow for neighborhood offset
+    xs_shifted = xs + neighbourhood
+    ys_shifted = ys + neighbourhood
+
+    # Create last timestamp matrix padded for neighborhood
+    max_x = np.max(xs_shifted) + neighbourhood + 1
+    max_y = np.max(ys_shifted) + neighbourhood + 1
+    last_ts = np.full((max_y, max_x), -np.inf)
+
+    keep = np.zeros_like(ts, dtype=bool)
+
+    # Define offset for neighborhood indexing
     offset_neg = neighbourhood
     offset_pos = neighbourhood + 1
-    
-    xs = xs + neighbourhood
-    ys = ys + neighbourhood
-    keep = np.zeros_like(ts, dtype=bool)
-    last_ts = np.full((np.max(ys) + neighbourhood * 2, 
-                       np.max(xs) +  + neighbourhood * 2), 
-                      -np.inf)
-    for i, (x, y, t) in enumerate(zip(xs, ys, ts)):
+
+    for i, (x, y, t) in enumerate(zip(xs_shifted, ys_shifted, ts)):
+        # Check if a previous event occurred recently at the same or neighboring location
         if t - last_ts[y, x] <= time_window:
             keep[i] = True
-        last_ts[y - offset_neg : y + offset_pos, 
-                x - offset_neg : x + offset_pos] = t #update
+
+        # Update the timestamps in the local neighborhood
+        last_ts[y - offset_neg : y + offset_pos,
+                x - offset_neg : x + offset_pos] = t
+
+    # Return only the events that passed the filter
     return {
-        'x' : events['x'][keep],
-        'y' : events['y'][keep],
-        'ts' : events['ts'][keep],
-        'pol' : events['pol'][keep],
-        }
+        'x': xs[keep],
+        'y': ys[keep],
+        'ts': ts[keep],
+        'pol': np.array(events['pol'])[keep],
+    }
 
 def filter_spatiotemporal(in_dict, **kwargs):
     # check to see if this is dvs type:

--- a/bimvee/importAe.py
+++ b/bimvee/importAe.py
@@ -86,7 +86,7 @@ def importAe(**kwargs):
             mostCommonFileType = max(set(fileTypes), key=fileTypes.count)
             if mostCommonFileType == 'log':
                 kwargs['fileFormat'] = 'iityarp'
-            elif mostCommonFileType == 'png':
+            elif mostCommonFileType in ['png', 'jpg', 'jpeg']:
                 kwargs['fileFormat'] = 'frames'
             else:
                 # recurse into this folder

--- a/bimvee/importIitYarp.py
+++ b/bimvee/importIitYarp.py
@@ -75,6 +75,7 @@ from .timestamps import unwrapTimestamps, zeroTimestampsForAChannel, rezeroTimes
 from .split import selectByLabel
 from bimvee.importBoundingBoxes import importBoundingBoxes
 from bimvee.importSkeleton import importSkeleton
+from bimvee.importEyeTracking import importEyeTracking
 from tqdm import tqdm
 
 def decodeEvents(data, **kwargs):
@@ -800,6 +801,8 @@ def importIitYarpRecursive(**kwargs):
             tsOffset = importIitYarpInfoLog(**kwargs)
         if file == 'ground_truth.csv':
             boundingBoxes = importBoundingBoxes(**kwargs)
+        if file == 'gt.json':
+            eyes = importEyeTracking(**kwargs)
         if file == 'skeleton.json':
             skeleton = importSkeleton(**kwargs)
     if len(importedDicts) == 0:
@@ -811,6 +814,8 @@ def importIitYarpRecursive(**kwargs):
         addGroundTruth(boundingBoxes, importedDicts, 'boundingBoxes')
     if skeleton is not None:
         addGroundTruth(skeleton, importedDicts, 'skeleton')
+    if eyes is not None:
+        addGroundTruth(eyes, importedDicts, 'eyeTracking')
     return importedDicts
 
 

--- a/bimvee/importIitYarp.py
+++ b/bimvee/importIitYarp.py
@@ -75,7 +75,6 @@ from .timestamps import unwrapTimestamps, zeroTimestampsForAChannel, rezeroTimes
 from .split import selectByLabel
 from bimvee.importBoundingBoxes import importBoundingBoxes
 from bimvee.importSkeleton import importSkeleton
-from bimvee.importEyeTracking import importEyeTracking
 from tqdm import tqdm
 
 def decodeEvents(data, **kwargs):
@@ -164,7 +163,7 @@ def decodeEvents(data, **kwargs):
             y = np.uint16(dataDvs[:, 1] & 0xFF)
             dataDvs[:, 1] >>= 10
         else:  # 24bit - default
-            x = np.uint16(dataDvs[:, 1] & 0x7FF)
+            x = np.uint16(dataDvs[:, 1] & 0x3FF)
             dataDvs[:, 1] >>= 11
             y = np.uint16(dataDvs[:, 1] & 0x3FF)
             dataDvs[:, 1] >>= 10
@@ -709,6 +708,7 @@ def importIitYarpDataLog(**kwargs):
         eventsToDecode = []
         timestamps = []
         check_if_with_ts = False
+        bitString_accum = []
         for c in tqdm(content):
             firstQuoteIdx = c.find(b'\"')
             lastQuoteIdx = c[::-1].find(b'\"')
@@ -716,8 +716,11 @@ def importIitYarpDataLog(**kwargs):
             data = c[firstQuoteIdx + 1:-(lastQuoteIdx + 1)]
             bitStrings = np.frombuffer(fromStringNested(data), np.uint32)
             if not check_if_with_ts:
-                with_ts = np.all(sorted(bitStrings[::2]) == bitStrings[::2])
-                check_if_with_ts = True
+                bitString_accum.extend(bitStrings)
+                if len(bitString_accum) > 20:
+                    timestamps_to_check = np.array(bitString_accum[::2], dtype=np.int64)
+                    with_ts = np.all(np.diff(timestamps_to_check) >= 0)
+                    check_if_with_ts = True
             eventsToDecode.append(bitStrings)
             timestamps += [float(ts) / 0.000001]*len(bitStrings)
         if with_ts:
@@ -801,8 +804,6 @@ def importIitYarpRecursive(**kwargs):
             tsOffset = importIitYarpInfoLog(**kwargs)
         if file == 'ground_truth.csv':
             boundingBoxes = importBoundingBoxes(**kwargs)
-        if file == 'gt.json':
-            eyes = importEyeTracking(**kwargs)
         if file == 'skeleton.json':
             skeleton = importSkeleton(**kwargs)
     if len(importedDicts) == 0:
@@ -814,8 +815,6 @@ def importIitYarpRecursive(**kwargs):
         addGroundTruth(boundingBoxes, importedDicts, 'boundingBoxes')
     if skeleton is not None:
         addGroundTruth(skeleton, importedDicts, 'skeleton')
-    if eyes is not None:
-        addGroundTruth(eyes, importedDicts, 'eyeTracking')
     return importedDicts
 
 

--- a/bimvee/importIniAedat.py
+++ b/bimvee/importIniAedat.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (C) 2020 Event-driven Perception for Robotics
+Authors: Sim Bamford
+
+This program is free software: you can redistribute it and/or modify it under 
+the terms of the GNU General Public License as published by the Free Software 
+Foundation, either version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY 
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with 
+this program. If not, see <https://www.gnu.org/licenses/>.
+
+Intended as part of bimvee (Batch Import, Manipulation, Visualisation and Export of Events etc)
+importIniAedat is a function for importing timestamped address-event data, given
+a path or a file containing an aedat file in the format used by INI / Inilabs /
+Inivation.
+The output is a file-level container in bimvee format.
+In general this is a dict containing:
+    - info
+    - data
+    info: will contain minimally:
+        - filePathAndName
+        - fileFormat
+    data: this is a list of dicts, one for each sensor or "channel" which has 
+    been imported. Bear in mind that sub-functions may optionally split or join 
+    channels. Within each dict, there is a field for each type of data contained.
+    Each of these fields is a dict containing a numpy array for timestamps 'ts'
+    (one row per event), and a np array for each type of data, with a row for 
+    each of those timestamps.
+
+    
+    
+    In particular there will be at least an 'ear' field, containing at least:
+        ts            (timestamp)
+        freq          (frequency channel, incresing addr -> decreasing frequency)
+    and possibly:
+        pol           (polarity 0 -> positive; 1 -> negative)
+        ch            (channel: 0 -> left; 1 -> right)
+        xso           (Olive model: 0 -> MSO; 1 -> LSO)
+        auditoryModel (auditory model: 0 -> cochlea; 1 -> superior olivary complex)
+        itdNeuron     (Addresses of Interaural-time-difference neurons)
+        
+There are basic formats corresponding to Ini Aedat v1 and 2.
+Files don't necessarily contain headers to disambiguate these, therefore the
+user must specify in kwargs any deviations from the following assumptions:
+    (loosely following https://github.com/jpdominguez/pyNAVIS/blob/master/src/pyNAVIS/main_settings.py)
+    codec: 'Addr2Bytes' i.e. [address(2-bytes) timestamp(4-bytes)] default
+              'Addr4Bytes' i.e. [address(4-bytes) timestamp(4-bytes)]
+    stereo = True
+    splitByChannel = False (i.e. left vs right into separate channel dicts)
+    numChannelBits: 5 (number of bits used for frequency channel addresses per sensor)
+    tsTick: 1e-6 (i.e. an integer time increment corresponds to 1 microsecond)
+    polarised: True (i.e. decode polarity of spikes)
+    zeroTime: True (whether to offset timestamps so that they start with zero)
+    
+    The address is interpretted as: 0...0cf...fp    where:
+        p is the polarity bit and may or may not be present
+        f are the frequency bits - there are ceil(log_2(numChannels))of these
+        c is the channel bit - left vs right, and may or may not be present.
+    
+"""
+
+#%%
+
+import os
+import numpy as np
+
+# local imports
+from .timestamps import zeroTimestampsForADataType
+from .split import splitByLabel
+
+
+def ImportAedat(aedat):
+    """
+    Parameters
+    ----------
+    args :
+    Returns
+    -------
+    """
+
+# To handle: missing args; search for file to open - request to user
+
+    with open(aedat['importParams']['filePath'], 'rb') as aedat['importParams']['fileHandle']:
+        aedat = ImportAedatHeaders(aedat)
+        if aedat['info']['fileFormat'] < 3:
+            return ImportAedatDataVersion1or2(aedat)
+        else:
+            return ImportAedatDataVersion3(aedat)
+
+
+def importIniAedat(**kwargs):
+    filePathOrName = kwargs.get('filePathOrName')
+    if not os.path.exists(filePathOrName):
+        raise FileNotFoundError("File or folder not found.")
+    # Move forward assuming that it's a single file
+    # TODO: implement hierarchical descent through folders
+    codec = kwargs.get('codec', 'addr4Bytes')
+    addrSize = 4 if codec == 'addr4Bytes' else 2
+    importFromByte = kwargs.get('importFromByte', 0)
+    importMaxBytes = kwargs.get('importMaxBytes')
+    headers = ''
+    with open(filePathOrName, 'rb') as file:
+        file.seek(importFromByte)
+
+        ## Check header ##
+        lt = file.readline()
+        while lt and lt[0] == ord("#"):
+            headers = headers + lt
+            importFromByte += len(lt)
+            lt = file.readline()
+        file.seek(0, 2)
+        eof = file.tell()
+        # TODO: headers to info
+
+        # Establish how far ahead to read
+        if importMaxBytes is None:
+            importMaxBytes = eof - importFromByte
+        else:
+            importMaxBytes -= np.mod(importMaxBytes, addrSize + 4) # Import a multiple of the word size
+            # Check if importMaxBytes is "feasible" (not beyond the file size)?
+            if eof > importFromByte + importMaxBytes:
+                importMaxBytes = eof - importFromByte
+                
+        # Now Read from the start point
+        file.seek(importFromByte)
+        events = file.read(importMaxBytes)
+        
+        # Pass out where we got to
+        if file.read(1) is None:
+            kwargs['importedToByte'] = 'EOF'
+        else:
+            kwargs['importedToByte'] = file.tell() - 2
+            # - 2 compensates for the small read-ahead just performed to test EOF
+
+        # Convert to uint16 - it's the highest common denominator for the address format possibilities. 
+#           dt = np.dtype(int)
+#>>> dt = dt.newbyteorder('>')
+#>>> np.frombuffer(buf, dtype=dt) 
+ 
+        events = np.frombuffer(events, np.uint8)
+        # The following is one way to recover big-endian order while still using np.frombuffer
+        # TODO: feels like there should be a better way
+        events = events.reshape((-1, addrSize + 4)).astype(np.uint32)
+        tsBytes = events[:, -4:]
+        ts = tsBytes[:, -1]
+        for byteIdx in range(3):
+            ts = ts + tsBytes[:, byteIdx] * 2 ** (8 * (4 - byteIdx))
+        #ts = events[:, -2].astype(np.uint32) * 2**16 + events[:, -1]
+        earDict = {'ts': ts}
+        if addrSize == 4:
+            addr = (events[:, 0] * 2**24 +
+                    events[:, 1] * 2**16 +
+                    events[:, 2] * 2**8 +
+                    events[:, 3])
+        else:
+            addr = (events[:, 0] * 2**8 +
+                    events[:, 1])
+        if kwargs.get('polarised', ('polarized', True)):
+            earDict['pol'] = np.bool_(addr & 0x01)
+            addr = addr >> 1
+        numChannelBits = kwargs.get('numChannelBits', 5)
+        earDict['freq'] = np.uint16(addr & (2**numChannelBits -1))
+        addr >>= numChannelBits
+        if kwargs.get('stereo', True):
+            earDict['ch'] = np.uint8(addr & 0x01)
+#                'itdNeuronIds': itdNeuronIds,
+#                'auditoryModel': auditoryModel,
+#                'xsoType': xsoType,
+#        xsoType = np.uint8(addr & 0x01)
+#        addr >>= 1
+#        auditoryModel = np.uint8(addr & 0x01)
+#        addr >>= 3
+#        itdNeuronIds = np.uint8(addr & 0x7F)
+#        addr >>= 10
+    if kwargs.get('zeroTimestamps', True):
+        zeroTimestampsForADataType(earDict) # TODO: This should return a new dict
+    tsTick = kwargs.get('tsTick', 1e-6)
+    earDict['ts'] = earDict['ts'].astype(np.float64) * tsTick
+    if kwargs.get('stereo', True) and kwargs.get('splitByChannel', True):
+        channels = splitByLabel(earDict, 'ch')
+        if 0 in channels.keys():
+            channels['left'] = {'ear': channels.pop(0)}
+        if 1 in channels.keys():
+            channels['right'] = {'ear': channels.pop(1)}
+    else:
+        channels = {'general': {'ear': earDict}}
+
+    if headers == '':
+        kwargs['headers'] = headers
+    outDict = {
+        'info': kwargs,
+        'data': channels
+        }
+    outDict['info']['fileFormat'] = 'iniaedat'
+    return outDict

--- a/bimvee/player.py
+++ b/bimvee/player.py
@@ -18,23 +18,30 @@ from bimvee.plotDvsContrast import getEventImageForTimeRange
 import math
 import time 
 
-class ViewerDvs():
+from bimvee.visualisers.visualiserDvs import VisualiserDvs
+from bimvee.visualisers.visualiserFrame import VisualiserFrame, findNearest
 
-    def __init__(self, events, ax):
-        # let's assume that the container is directly a single dvs event container
-        self.events = events
+class ViewerDvs(VisualiserDvs):
+
+    def __init__(self, data, ax):
+        #self.data = events
         self.ax = ax
-        self.dimX = np.max(self.events['x']) + 1
-        self.dimY = np.max(self.events['y']) + 1
-        self.contrast = 1 
-        self.time_window = 0.03
-        self.label = events.get('label', '')
+        # Making the dimensions instance attributes - TODO: push this improvement down into the visualisers
+        self.dimX = data.get('dimX') or np.max(data['x']) + 1
+        self.dimY = data.get('dimY') or np.max(data['y']) + 1
+        # Currently, the base class requires the data to carry dimX/Y attributes:
+        data['dimX'] = self.dimX
+        data['dimY'] = self.dimY
+        self.contrast = 1
+        self.time_window = 0.03 # this default is overwritten by the slider
+        self.label = data.get('label', '')
+        self.image_type = 'not_polarized'
+        super(ViewerDvs, self).__init__(data)
         
     def update(self, target_time):
-        # Remove previous data
-        self.ax.clear()
-        
-        # This function should be pushed to a visualiser
+            
+        event_image = self.get_frame(target_time, self.time_window, image_type=self.image_type, contrast=self.contrast) # to do -get the lower function internalise contrast
+        '''
         startTime = target_time - self.time_window / 2
         endTime = target_time + self.time_window / 2
         event_image = getEventImageForTimeRange(
@@ -47,11 +54,46 @@ class ViewerDvs():
             image_type='not_polarized')
         event_image += self.contrast
         self.ax.imshow(event_image, cmap='gray', vmin=0, vmax=self.contrast*2)
+        '''
+        # Remove previous data
+        self.ax.clear()
+        self.ax.imshow(event_image, cmap='gray', vmin=0, vmax=255)
         self.ax.set_xticks([])
         self.ax.set_xticks([], minor=True)
         self.ax.set_yticks([])
         self.ax.set_yticks([], minor=True)
         self.ax.set_title(self.label)
+
+class ViewerFrame(VisualiserFrame):
+
+    def __init__(self, data, ax):
+        #self.data = events
+        self.ax = ax
+        # Making the dimensions instance attributes - TODO: push this improvement down into the visualisers
+        #self.dimX = data.get('dimX') or np.max(data['x']) + 1
+        #self.dimY = data.get('dimY') or np.max(data['y']) + 1
+        # Currently, the base class requires the data to carry dimX/Y attributes:
+        #data['dimX'] = self.dimX
+        #data['dimY'] = self.dimY
+        #self.contrast = 1
+        self.time_window = 0.03 # for frames, need to decide between either showing nearest frame within window, or showing the nearest one in any case
+        self.label = data.get('label', '')
+        self.image_type = 'not_polarized'
+        super(ViewerFrame, self).__init__(data)
+        
+    def update(self, target_time):
+            
+        image = self.get_frame(target_time, self.time_window) 
+        # Remove previous data
+        self.ax.clear()
+        self.ax.imshow(image, cmap='gray', vmin=0, vmax=255)
+        self.ax.set_xticks([])
+        self.ax.set_xticks([], minor=True)
+        self.ax.set_yticks([])
+        self.ax.set_yticks([], minor=True)
+        self.ax.set_title(self.label)
+
+
 
 # TODO: This functionality, or some of it, may belong in the container class
 def get_dvs_data(container, label=[]):
@@ -61,6 +103,7 @@ def get_dvs_data(container, label=[]):
         and 'x' in keys
         and 'y' in keys):
         container['label'] = '_'.join(label)
+        container['data_type'] = 'dvs'
         return [container]
         # TODO: put stricter check here for data type
     else:
@@ -69,6 +112,21 @@ def get_dvs_data(container, label=[]):
             if type(value) == dict:
                 dvs_dicts = dvs_dicts + get_dvs_data(value, label + [str(key)])
         return dvs_dicts
+
+def get_frame_data(container, label=[]):
+    keys = container.keys()
+    if ('ts' in keys
+        and 'frames' in keys):
+        container['label'] = '_'.join(label)
+        container['data_type'] = 'frame'
+        return [container]
+        # TODO: put stricter check here for data type
+    else:
+        frame_dicts = []
+        for key, value in container.items():
+            if type(value) == dict:
+                frame_dicts = frame_dicts + get_frame_data(value, label + [str(key)])
+        return frame_dicts
 
 
 from math import log10, floor
@@ -85,7 +143,9 @@ class Player():
     def __init__(self, container):
         self.fig = plt.figure()
         dvs_containers = get_dvs_data(container)
-        num_containers = len(dvs_containers)
+        frame_containers = get_frame_data(container)
+        all_rendered_containers = dvs_containers + frame_containers
+        num_containers = len(all_rendered_containers)
         num_cols = math.ceil(math.sqrt(num_containers))
         num_rows = math.ceil(num_containers / num_cols)
         x_min = 0
@@ -99,7 +159,7 @@ class Player():
         self.last_time = time.time()
         self.speed = 1
         
-        for idx, events in enumerate(dvs_containers):
+        for idx, rendered_container in enumerate(all_rendered_containers):
             row_idx = math.floor(idx / num_cols)
             col_idx = idx % num_cols
             ax = self.fig.add_axes([
@@ -107,11 +167,14 @@ class Player():
                 y_min + y_spacing / 2 + row_idx / max((num_rows - 1), 1) * y_extent_per_row, 
                 x_extent_per_col - x_spacing / 2, 
                 y_extent_per_row - y_spacing / 2]) # xmin ymin x-extent y-extent
-            viewer = ViewerDvs(events, ax)
+            if rendered_container['data_type'] == 'dvs':
+                viewer = ViewerDvs(rendered_container, ax)
+            elif rendered_container['data_type'] == 'frame':
+                viewer = ViewerFrame(rendered_container, ax)
             self.viewers.append(viewer)
         
         # recalculations here based on container(s)
-        max_times = [events['ts'][-1] for events in dvs_containers]
+        max_times = [rendered_container['ts'][-1] for rendered_container in all_rendered_containers]
         self.max_time = max(max_times)
         
         # Add controls
@@ -139,9 +202,13 @@ class Player():
             valmax=3,
             valinit=1.5)
 
-        self.ax_button_play = self.fig.add_axes([0.05, 0.85, 0.05, 0.05]) # xmin ymin x-extent y-extent
+        self.ax_button_play = self.fig.add_axes([0.05, 0.8, 0.05, 0.05]) # xmin ymin x-extent y-extent
         self.button_play = Button(self.ax_button_play, 'Pause') #, color="blue")
         self.button_play.on_clicked(self.toggle_play)
+                        
+        self.ax_button_pol = self.fig.add_axes([0.05, 0.875, 0.05, 0.05]) # xmin ymin x-extent y-extent
+        self.button_pol = Button(self.ax_button_pol, 'Polarity') #, color="blue")
+        self.button_pol.on_clicked(self.toggle_pol)
                         
         self.slider_time.on_changed(self.update_viewers)
         self.slider_speed.on_changed(self.slider_speed_manual_control)
@@ -167,6 +234,14 @@ class Player():
             self.last_time = time.time()
             self.is_playing = True
             self.button_play.label.set_text('Pause')
+                        
+    def toggle_pol(self, val):
+        for viewer in self.viewers:
+            if type(viewer) == ViewerDvs:
+                if viewer.image_type == 'not_polarized':
+                    viewer.image_type = 'count'
+                else:
+                    viewer.image_type = 'not_polarized'
                         
     # update a single plot pane - this should be pushed to a visualiser subclass
     def update_viewers(self, val):

--- a/bimvee/player.py
+++ b/bimvee/player.py
@@ -18,23 +18,29 @@ from bimvee.plotDvsContrast import getEventImageForTimeRange
 import math
 import time 
 
-class ViewerDvs():
+from bimvee.visualisers.visualiserDvs import VisualiserDvs
+from bimvee.visualisers.visualiserFrame import VisualiserFrame, findNearest
 
-    def __init__(self, events, ax):
-        # let's assume that the container is directly a single dvs event container
-        self.events = events
+class ViewerDvs(VisualiserDvs):
+
+    def __init__(self, data, ax):
+        #self.data = events
         self.ax = ax
-        self.dimX = np.max(self.events['x']) + 1
-        self.dimY = np.max(self.events['y']) + 1
-        self.contrast = 1 
-        self.time_window = 0.03
-        self.label = events.get('label', '')
+        # Making the dimensions instance attributes - TODO: push this improvement down into the visualisers
+        self.dimX = data.get('dimX') or np.max(data['x']) + 1
+        self.dimY = data.get('dimY') or np.max(data['y']) + 1
+        # Currently, the base class requires the data to carry dimX/Y attributes:
+        data['dimX'] = self.dimX
+        data['dimY'] = self.dimY
+        self.contrast = 1
+        self.time_window = 0.03 # this default is overwritten by the slider
+        self.label = data.get('label', '')
+        super(ViewerDvs, self).__init__(data)        
         
     def update(self, target_time):
-        # Remove previous data
-        self.ax.clear()
-        
-        # This function should be pushed to a visualiser
+    
+        event_image = self.get_frame(target_time, self.time_window, contrast=self.contrast) # to do -get the lower function internalise contrast
+        '''
         startTime = target_time - self.time_window / 2
         endTime = target_time + self.time_window / 2
         event_image = getEventImageForTimeRange(
@@ -47,6 +53,10 @@ class ViewerDvs():
             image_type='not_polarized')
         event_image += self.contrast
         self.ax.imshow(event_image, cmap='gray', vmin=0, vmax=self.contrast*2)
+        '''
+        # Remove previous data
+        self.ax.clear()
+        self.ax.imshow(event_image, cmap='gray', vmin=0, vmax=255)
         self.ax.set_xticks([])
         self.ax.set_xticks([], minor=True)
         self.ax.set_yticks([])

--- a/bimvee/plotDvsSpaceTime.py
+++ b/bimvee/plotDvsSpaceTime.py
@@ -21,7 +21,8 @@ and creates a point cloud viewer containing
 '''
 
 import numpy as np
-import pptk
+#import pptk
+import matplotlib.pyplot as plt
 
 from .split import cropSpaceTime
 
@@ -56,8 +57,20 @@ def plotDvsSpaceTime(inDicts, **kwargs):
     timeRange = inDict['ts'][-1] - inDict['ts'][0]
     spatialDim = max(max(inDict['x']), max(inDict['y']))
     scalingFactor = timeRange / spatialDim
-    events = np.concatenate((inDict['x'][:, np.newaxis] * scalingFactor, 
-                             inDict['y'][:, np.newaxis] * scalingFactor, 
-                             inDict['ts'][:, np.newaxis]), axis=1)
-    pptkViewer = pptk.viewer(events) 
-    return pptkViewer
+    #events = np.concatenate((inDict['x'][:, np.newaxis] * scalingFactor, 
+    #                         inDict['y'][:, np.newaxis] * scalingFactor, 
+    #                         inDict['ts'][:, np.newaxis]), axis=1)
+    #pptkViewer = pptk.viewer(events) 
+    #return pptkViewer
+    axes = kwargs.get('axes', None) 
+    if axes is None:
+        fig = plt.figure()
+        axes = fig.add_subplot(projection='3d')
+    axes.scatter(
+        inDict['x'] * scalingFactor, 
+        inDict['y'] * scalingFactor, 
+        inDict['ts']
+    )
+    axes.set_xlabel('X')
+    axes.set_ylabel('Y')
+    axes.set_zlabel('Time')

--- a/bimvee/plotSpikeogram.py
+++ b/bimvee/plotSpikeogram.py
@@ -69,7 +69,7 @@ def plotSpikeogramDvs(inDict, **kwargs):
                 print('Channel ' + channelName + ' skipped because it contains no polarity data')
         return
     # Break out data arrays for cleaner code
-    print('plotSpikeogram working: ' + kwargs['title'])
+    print('plotSpikeogram working: ' + kwargs.get('title', ''))
     x = inDict['x']
     y = inDict['y']
     ts = inDict['ts']

--- a/bimvee/split.py
+++ b/bimvee/split.py
@@ -64,15 +64,15 @@ def selectByBool(inDict, selectedEvents):
     if not np.any(selectedEvents):
         return None
     outDict = {}
-    for fieldName in inDict.keys():
+    for key, value in inDict.items():
         try:
-            assert len(inDict[fieldName]) == len(selectedEvents)
-            if isinstance(inDict[fieldName], list):
-                outDict[fieldName] = list(compress(inDict[fieldName], selectedEvents))
+            assert len(value) == len(selectedEvents)
+            if isinstance(value, list):
+                outDict[key] = list(compress(value, selectedEvents))
             else:
-                outDict[fieldName] = inDict[fieldName][selectedEvents]
+                outDict[fkey] = value[selectedEvents]
         except (AssertionError, TypeError): # TypeError for case that value has no len(); #AssertionError, in case it does but that len is not the same as the ts len.
-            outDict[fieldName] = inDict[fieldName]
+            outDict[key] = value
     return outDict
 
 

--- a/bimvee/split.py
+++ b/bimvee/split.py
@@ -40,7 +40,7 @@ from itertools import compress
 from math import fabs
 
 # local imports
-from .timestamps import rezeroTimestampsForImportedDicts, sortDataTypeDictByTime
+from .timestamps import sortDataTypeDictByTime
 
 # In selectByLabel, the field from which a value is selected already exists in the iDict
 def selectByLabel(inDict, labelName, labelValue):
@@ -157,62 +157,60 @@ If given a larger container, will split down all that it finds, realigning times
 If the container contains an info field, then the start and stopTime params
 will be added.
 '''
-def cropTime(inDict, **kwargs):
-    if isinstance(inDict, list):
-        return [cropTime(inDictInst, **kwargs) for inDictInst in inDict]
-    elif 'info' in inDict:
-        outDict = {'info': inDict['info'].copy(),
-                   'data': {}}
-        for channelName in inDict['data'].keys():
-            outDict['data'][channelName] = {}
-            for dataTypeName in inDict['data'][channelName].keys():
-                outDict['data'][channelName][dataTypeName] = cropTime(inDict['data'][channelName][dataTypeName], **kwargs)                
-        rezeroTimestampsForImportedDicts(outDict)
-        return outDict
-    elif 'ts' in inDict:
-        ts = inDict['ts']
-        if not np.any(ts): # the dataset is empty
-            return inDict
-        startTime = kwargs.get('startTime', 
-                    kwargs.get('minTime', 
-                    kwargs.get('beginTime', 
-                    kwargs.get('startTs', 
-                    kwargs.get('minTs', 
-                    kwargs.get('beginTs', 
-                    ts[0]))))))
-        stopTime = kwargs.get('stopTime', 
-                   kwargs.get('maxTime', 
-                   kwargs.get('endTime', 
-                   kwargs.get('stopTs', 
-                   kwargs.get('maxTs', 
-                   kwargs.get('endTs', 
-                   ts[-1]))))))
-        if startTime == ts[0] and stopTime == ts[-1]:
-            # No cropping to do - pass out the dict unmodified
-            return inDict
-        startIdx = np.searchsorted(ts, startTime, side='left')
-        stopIdx = np.searchsorted(ts, stopTime, side='right')
-        tsNew = ts[startIdx:stopIdx]
-        if kwargs.get('zeroTime', kwargs.get('zeroTimestamps', True)):
-            tsNew = tsNew - startTime
-        outDict = {'ts': tsNew}
-        for fieldName in inDict.keys():
-            if fieldName != 'ts':
-                field = inDict[fieldName]
-                try:
-                    outDict[fieldName] = field[startIdx:stopIdx]
-                except IndexError:
-                    outDict[fieldName] = field.copy() # This might fail for certain data types
-                except TypeError:
-                    outDict[fieldName] = field # This might fail for certain data types
-        if kwargs.get('zeroTime', kwargs.get('zeroTimestamps', True)):
-            tsOffsetOriginal = inDict.get('tsOffset', 0)
-            outDict['tsOffset'] = tsOffsetOriginal - startTime
-        return outDict
-    else:
-        # We assume that this is a datatype which doesn't contain ts, 
-        # so we pass it out unmodified
+def cropTimeSingle(inDict, **kwargs):    
+    ts = inDict['ts']
+    if not np.any(ts): # the dataset is empty
         return inDict
+    startTime = kwargs.get('startTime', 
+                kwargs.get('minTime', 
+                kwargs.get('beginTime', 
+                kwargs.get('startTs', 
+                kwargs.get('minTs', 
+                kwargs.get('beginTs', 
+                ts[0]))))))
+    stopTime = kwargs.get('stopTime', 
+               kwargs.get('maxTime', 
+               kwargs.get('endTime', 
+               kwargs.get('stopTs', 
+               kwargs.get('maxTs', 
+               kwargs.get('endTs', 
+               ts[-1]))))))
+    if startTime == ts[0] and stopTime == ts[-1]:
+        # No cropping to do - pass out the dict unmodified
+        return inDict
+    startIdx = np.searchsorted(ts, startTime, side='left')
+    stopIdx = np.searchsorted(ts, stopTime, side='right')
+    tsNew = ts[startIdx:stopIdx]
+    if kwargs.get('zeroTime', kwargs.get('zeroTimestamps', True)):
+        tsNew = tsNew - startTime
+    outDict = {'ts': tsNew}
+    for key, value in inDict.items():
+        if key != 'ts':
+            try:
+                outDict[key] = value[startIdx:stopIdx]
+            except IndexError:
+                outDict[key] = value.copy() # This might fail for certain data types
+            except TypeError:
+                outDict[key] = value # This might fail for certain data types
+    if kwargs.get('zeroTime', kwargs.get('zeroTimestamps', True)):
+        tsOffsetOriginal = inDict.get('tsOffset', 0)
+        outDict['tsOffset'] = tsOffsetOriginal - startTime
+    return outDict
+
+def cropTime(in_dict, **kwargs):
+    # descend the hierarchy to the base layer:
+    if isinstance(in_dict, list):
+        return [cropTime(elem, **kwargs) for elem in in_dict]
+    if 'ts' in in_dict.keys():
+        new_dict = cropTimeSingle(in_dict, **kwargs)
+    else:
+        new_dict = {}
+        for key, value in in_dict.items():
+            if type(value) == dict:
+                new_dict[key] = cropTime(value, **kwargs)
+            else:
+                new_dict[key] = value
+    return new_dict
 
 # Could apply to any datatype with separate xy arrays; at the time of writing:
 # dvs, flow
@@ -287,7 +285,8 @@ def cropSpaceFrame(inDict, **kwargs):
 
 def cropSpace(inDict, **kwargs):
     if isinstance(inDict, list):
-        return [cropSpace(inDictInst, **kwargs) for inDictInst in inDict]
+        return [cropSpace(elem, **kwargs) for elem in inDict]
+
     elif 'info' in inDict:
         outDict = {'info': inDict['info'].copy(),
                    'data': {}}
@@ -304,8 +303,9 @@ def cropSpace(inDict, **kwargs):
     elif 'point' in inDict:
         return cropSpacePoint(inDict, **kwargs)
     else:
-        # We assume that this is a datatype which doesn't contain x/y
-        # so we pass it out unmodified
+        new_dict = {}
+        for key, value in inDict.items():
+            new_dict[key] = cropSpace(value, **kwargs)
         # TODO: frame datatype could be cropped spatially but doesn't get caught by this method
         return inDict
 

--- a/bimvee/split.py
+++ b/bimvee/split.py
@@ -70,7 +70,7 @@ def selectByBool(inDict, selectedEvents):
             if isinstance(value, list):
                 outDict[key] = list(compress(value, selectedEvents))
             else:
-                outDict[fkey] = value[selectedEvents]
+                outDict[key] = value[selectedEvents]
         except (AssertionError, TypeError): # TypeError for case that value has no len(); #AssertionError, in case it does but that len is not the same as the ts len.
             outDict[key] = value
     return outDict
@@ -307,7 +307,7 @@ def cropSpace(inDict, **kwargs):
         for key, value in inDict.items():
             new_dict[key] = cropSpace(value, **kwargs)
         # TODO: frame datatype could be cropped spatially but doesn't get caught by this method
-        return inDict
+        return new_dict
 
 def cropSpaceTime(inDict, **kwargs):
     return cropSpace(cropTime(inDict, **kwargs), **kwargs)

--- a/bimvee/timestamps.py
+++ b/bimvee/timestamps.py
@@ -370,6 +370,51 @@ def getEvent(inDict, idx):
             continue
     return outDict
 
+'''
+The following three functions implement a naive rezeroing, assuming that the 
+purpose is to bring all the individual datadict time offsets into alignment.
+This may be useful if the time offsets all came from the same source.
+However, if a container has files which have been aligned and which have 
+different tsoffsets in order to achieve this, the following approach will break that,
+'''
+
+def findLargestTsOffset(in_dict):
+    if type(in_dict) == dict:
+        if 'tsOffset' in in_dict.keys():
+            return in_dict['tsOffset']
+        else:
+            tsOffset = float(-np.inf)
+            for key, value in in_dict.items():
+                tsOffset = max(
+                    tsOffset,
+                    findLargestTsOffset(value))
+            return tsOffset
+    else:
+        return -np.inf
+
+def applyOffset(in_dict, ts_offset):
+    if 'ts' in in_dict.keys():
+        ts_offset_current = in_dict.get('tsOffset', 0.0)
+        out_dict = {
+            'ts': in_dict['ts'] + ts_offset - ts_offset_current,
+            'tsOffset': ts_offset
+            }
+        for key, value in in_dict.items():
+            if key not in ['ts', 'tsOffset']:
+                out_dict[key] = value
+        return out_dict
+    else:
+        out_dict = {}
+        for key, value in in_dict.items():
+            if type(value) == dict:
+                out_dict[key] = applyOffset(value, ts_offset)
+        return out_dict
+
+def rezeroTimestampsGeneral(in_dict):
+    # Find largest (i.e. least negative) offset
+    ts_offset = findLargestTsOffset(in_dict)
+    # Now we have the least negative tsOffset, iterate through all, reapplying it
+    return applyOffset(in_dict, ts_offset)
 
 
 #%% LEGACY CODE - timestamps for different data types present in aedat

--- a/bimvee/visualisers/visualiserEyeTracking.py
+++ b/bimvee/visualisers/visualiserEyeTracking.py
@@ -60,8 +60,8 @@ class VisualiserEyeTracking(Visualiser):
                     if x == 'eye_closed':
                         out_dict[x] = val[0] and val[1]
                         continue
-                    cubic_interp = interp1d(data_to_interpolate['ts'], val, kind='linear')
-                    out_dict[x] = cubic_interp(time)
+                    linear_interp = interp1d(data_to_interpolate['ts'], val, kind='linear')
+                    out_dict[x] = linear_interp(time)
                 out_dict['interpolated'] = True
                 return out_dict
             return {k: self.get_data()[k][idx] for k in self.get_data().keys() if hasattr(self.get_data()[k], '__len__')}

--- a/bimvee/visualisers/visualiserEyeTracking.py
+++ b/bimvee/visualisers/visualiserEyeTracking.py
@@ -60,22 +60,8 @@ class VisualiserEyeTracking(Visualiser):
                     if x == 'eye_closed':
                         out_dict[x] = val[0] and val[1]
                         continue
-                    try:
-                        if x == 'eyeball_theta' or x == 'eyeball_phi':
-                            ang_dist = abs(radian_difference(val[0], val[-1]))
-                            is_far_enough = ang_dist > 0.05
-                        elif x == 'eyeball_radius':
-                            is_far_enough = abs(val[0] - val[-1]) > 10
-                        elif x == 'eyeball_x' or x == 'eyeball_y':
-                            is_far_enough = abs(val[0] - val[-1]) > 5
-                        interp_kind = 'linear'   # interp_kind = 'cubic' if is_far_enough else 'linear'
-                        try:
-                            cubic_interp = interp1d(data_to_interpolate['ts'], val, kind=interp_kind)
-                        except ValueError:
-                            cubic_interp = interp1d(data_to_interpolate['ts'], val, kind='linear')
-                        out_dict[x] = cubic_interp(time)
-                    except TypeError:
-                        continue
+                    cubic_interp = interp1d(data_to_interpolate['ts'], val, kind='linear')
+                    out_dict[x] = cubic_interp(time)
                 out_dict['interpolated'] = True
                 return out_dict
             return {k: self.get_data()[k][idx] for k in self.get_data().keys() if hasattr(self.get_data()[k], '__len__')}

--- a/bimvee/visualisers/visualiserEyeTracking.py
+++ b/bimvee/visualisers/visualiserEyeTracking.py
@@ -69,6 +69,7 @@ class VisualiserEyeTracking(Visualiser):
                         elif x == 'eyeball_x' or x == 'eyeball_y':
                             is_far_enough = abs(val[0] - val[-1]) > 5
                         interp_kind = 'linear'   # interp_kind = 'cubic' if is_far_enough else 'linear'
+                        print(interp_kind)
                         try:
                             cubic_interp = interp1d(data_to_interpolate['ts'], val, kind=interp_kind)
                         except ValueError:

--- a/bimvee/visualisers/visualiserEyeTracking.py
+++ b/bimvee/visualisers/visualiserEyeTracking.py
@@ -69,7 +69,6 @@ class VisualiserEyeTracking(Visualiser):
                         elif x == 'eyeball_x' or x == 'eyeball_y':
                             is_far_enough = abs(val[0] - val[-1]) > 5
                         interp_kind = 'linear'   # interp_kind = 'cubic' if is_far_enough else 'linear'
-                        print(interp_kind)
                         try:
                             cubic_interp = interp1d(data_to_interpolate['ts'], val, kind=interp_kind)
                         except ValueError:

--- a/bimvee/visualisers/visualiserEyeTracking.py
+++ b/bimvee/visualisers/visualiserEyeTracking.py
@@ -38,6 +38,7 @@ def radian_difference(rad1, rad2):
     diff = rad1 - rad2
     # Normalize the difference to be within [-π, π]
     return (diff + np.pi) % (2 * np.pi) - np.pi
+
 class VisualiserEyeTracking(Visualiser):
 
     data_type = 'eyeTracking'
@@ -59,22 +60,8 @@ class VisualiserEyeTracking(Visualiser):
                     if x == 'eye_closed':
                         out_dict[x] = val[0] and val[1]
                         continue
-                    try:
-                        if x == 'eyeball_theta' or x == 'eyeball_phi':
-                            ang_dist = abs(radian_difference(val[0], val[-1]))
-                            is_far_enough = ang_dist > 0.05
-                        elif x == 'eyeball_radius':
-                            is_far_enough = abs(val[0] - val[-1]) > 10
-                        elif x == 'eyeball_x' or x == 'eyeball_y':
-                            is_far_enough = abs(val[0] - val[-1]) > 5
-                        interp_kind = 'cubic' if is_far_enough else 'linear'
-                        try:
-                            cubic_interp = interp1d(data_to_interpolate['ts'], val, kind=interp_kind)
-                        except ValueError:
-                            cubic_interp = interp1d(data_to_interpolate['ts'], val, kind='linear')
-                        out_dict[x] = cubic_interp(time)
-                    except TypeError:
-                        continue
+                    linear_interp = interp1d(data_to_interpolate['ts'], val, kind='linear')
+                    out_dict[x] = linear_interp(time)
                 out_dict['interpolated'] = True
                 return out_dict
             return {k: self.get_data()[k][idx] for k in self.get_data().keys() if hasattr(self.get_data()[k], '__len__')}

--- a/bimvee/visualisers/visualiserEyeTracking.py
+++ b/bimvee/visualisers/visualiserEyeTracking.py
@@ -38,6 +38,7 @@ def radian_difference(rad1, rad2):
     diff = rad1 - rad2
     # Normalize the difference to be within [-π, π]
     return (diff + np.pi) % (2 * np.pi) - np.pi
+
 class VisualiserEyeTracking(Visualiser):
 
     data_type = 'eyeTracking'
@@ -67,7 +68,7 @@ class VisualiserEyeTracking(Visualiser):
                             is_far_enough = abs(val[0] - val[-1]) > 10
                         elif x == 'eyeball_x' or x == 'eyeball_y':
                             is_far_enough = abs(val[0] - val[-1]) > 5
-                        interp_kind = 'cubic' if is_far_enough else 'linear'
+                        interp_kind = 'linear'   # interp_kind = 'cubic' if is_far_enough else 'linear'
                         try:
                             cubic_interp = interp1d(data_to_interpolate['ts'], val, kind=interp_kind)
                         except ValueError:


### PR DESCRIPTION
## Summary

This PR fixes unsafe and unreliable detection of `with_ts` in `.log` file decoding via the `importIitYarpDataLog` function in `importIitYarp.py`.

### Key Fixes

- w or w/o timestamps detection until more than 20 events are accumulated
- Casts to `int64` to avoid silent `uint32` overflow
- Prevents false positives due to short or noisy packets

Fixes issue #52

---

## Notes

I have selected the version of the source code that most closely resembles the one currently distributed via the `pip` channel.  
While the version I edited may include some unrelated modifications, **only the following changes are mine**:

```python
bitString_accum = []

for c in tqdm(content):
    ...
    bitStrings = np.frombuffer(fromStringNested(data), np.uint32)

    if not check_if_with_ts:
        bitString_accum.extend(bitStrings)
        if len(bitString_accum) > 20:
            timestamps_to_check = np.array(bitString_accum[::2], dtype=np.int64)
            with_ts = np.all(np.diff(timestamps_to_check) >= 0)
            check_if_with_ts = True